### PR TITLE
unfilled bug: when item.disabled is a function, it is now called on item.click

### DIFF
--- a/jquery.contextMenu.js
+++ b/jquery.contextMenu.js
@@ -574,13 +574,21 @@ var // currently active contextMenu trigger
                 opt = data.contextMenu,
                 root = data.contextMenuRoot,
                 key = data.contextMenuKey,
-                callback;
+                callback,
+                disabled;
 
-            // abort if the key is unknown or disabled
-            if (!opt.items[key] || $this.hasClass('disabled')) {
-                return;
-            }
-
+    		// abort if the key is unknown or disabled
+            if ($.isFunction(opt.items[key].disabled)) {
+				disabled = opt.items[key].disabled.call(key, root);
+			}
+			else {
+				disabled = opt.items[key].disabled;				
+			}
+				
+			if (!opt.items[key] || disabled) {
+				return;
+			}
+            
             e.preventDefault();
             e.stopImmediatePropagation();
 


### PR DESCRIPTION
unfilled bug: when a menu.item.disabled element is a function, and it evaluates to false (item is enabled), the item callback was not called, as if item was disabled. This version check if menu.item.disabled is a function, and calls it as stated in the doc, when the item is clicked.
