### PR TITLE
Fixed an IE8 issue where the context menu would stay on the screen if a combo box or input field received focus

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1004,7 +1004,7 @@ var // currently active contextMenu trigger
         },
         layer: function(opt, zIndex) {
             // add transparent layer for click area
-            return opt.$layer = $('<div id="context-menu-layer" style="position:fixed; z-index:' + zIndex + '; top:0; left:0; opacity: 0;"></div>')
+			return opt.$layer = $('<div id="context-menu-layer" style="position:fixed; z-index:' + zIndex + '; top:0; left:0; opacity: 0; filter: alpha(opacity=0); background-color: #000;"></div>')
                 .css({height: $win.height(), width: $win.width(), display: 'block'})
                 .data('contextMenuRoot', opt)
                 .insertBefore(this)


### PR DESCRIPTION
If there is an input box of combo box on the screen and it receives
focus before clicking on the invisible dismissal layer
(#context-menu-layer) the context menu won't disappear. I've added a IE
specific opacity filter and background color of white to
# context-menu-layer so the layer receives a click and properly

dismisses the context menu.
