### PR TITLE
When using the Build callback, if no items are defined then create no me...

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -203,6 +203,9 @@ var // currently active contextMenu trigger
                 if (e.data.build) {
                     // dynamically build menu on invocation
                     $.extend(true, e.data, defaults, e.data.build($currentTrigger, e) || {});
+                    // no items? don't show a menu
+                    if ($.isEmptyObject(e.data.items))
+                        return;
                     op.create(e.data);
                 }
                 // show menu


### PR DESCRIPTION
When using the Build callback, if no items are defined/setup by the callback, then do not show a menu
