### PR TITLE
Added backreference to the $trigger element when building dynamic menus.

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -220,6 +220,9 @@ var // currently active contextMenu trigger
                         throw new Error('No Items sepcified');
                     }
                     
+                    // backreference for custom command type creation
+                    e.data.$trigger = $currentTrigger;
+                    
                     op.create(e.data);
                 }
                 // show menu


### PR DESCRIPTION
This is useful when a custom command type is defined which builds itself off of the trigger element.  For example, a custom command type which sets its color to the same as the clicked element.
