### PR TITLE
Destroy left some stuff out.

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1306,7 +1306,7 @@ $.contextMenu = function(operation, options) {
                 } catch(e) {
                     menus[namespaces[o.selector]] = null;
                 }
-                
+                $('#context-menu-layer').remove();
                 $document.off(namespaces[o.selector]);
             }
             break;


### PR DESCRIPTION
When there are multiple namespaces the background is still present
after destroy has run. This will remove the background after everything
has been removed.
