### PR TITLE
Background wasn't removed on destroy

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1306,8 +1306,9 @@ $.contextMenu = function(operation, options) {
                 } catch(e) {
                     menus[namespaces[o.selector]] = null;
                 }
-                $('#context-menu-layer').remove();
+                
                 $document.off(namespaces[o.selector]);
+                $('#context-menu-layer').remove();
             }
             break;
         


### PR DESCRIPTION
When you have multiple context menus on the page and remove one of them the background div was still on the page.
