### PR TITLE
Twitter Bootstrap CSS-Namespace Conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
 .DS_Store
+/.idea/.name
+/.idea/encodings.xml
+/.idea/inspectionProfiles/profiles_settings.xml
+/.idea/jQuery-contextMenu.iml
+/.idea/misc.xml
+/.idea/modules.xml
+/.idea/scopes/scope_settings.xml
+/.idea/vcs.xml
+/.idea/workspace.xml

--- a/src/jquery.contextMenu.css
+++ b/src/jquery.contextMenu.css
@@ -88,14 +88,14 @@
     http://css-tricks.com/13224-pseudo-spriting/ to get an idea of how to implement 
     .context-menu-item.icon:before {}
  */
-.context-menu-item.icon { min-height: 18px; background-repeat: no-repeat; background-position: 4px 2px; }
-.context-menu-item.icon-edit { background-image: url(images/page_white_edit.png); }
-.context-menu-item.icon-cut { background-image: url(images/cut.png); }
-.context-menu-item.icon-copy { background-image: url(images/page_white_copy.png); }
-.context-menu-item.icon-paste { background-image: url(images/page_white_paste.png); }
-.context-menu-item.icon-delete { background-image: url(images/page_white_delete.png); }
-.context-menu-item.icon-add { background-image: url(images/page_white_add.png); }
-.context-menu-item.icon-quit { background-image: url(images/door.png); }
+.context-menu-item.context-menu-icon { min-height: 18px; background-repeat: no-repeat; background-position: 4px 2px; }
+.context-menu-item.context-menu-icon-edit { background-image: url(images/page_white_edit.png); }
+.context-menu-item.context-menu-icon-cut { background-image: url(images/cut.png); }
+.context-menu-item.context-menu-icon-copy { background-image: url(images/page_white_copy.png); }
+.context-menu-item.context-menu-icon-paste { background-image: url(images/page_white_paste.png); }
+.context-menu-item.context-menu-icon-delete { background-image: url(images/page_white_delete.png); }
+.context-menu-item.context-menu-icon-add { background-image: url(images/page_white_add.png); }
+.context-menu-item.context-menu-icon-quit { background-image: url(images/door.png); }
 
 /* vertically align inside labels */
 .context-menu-input > label > * { vertical-align: top; }

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1058,7 +1058,7 @@ var // currently active contextMenu trigger
                 
                     // add icons
                     if (item.icon) {
-                        $t.addClass("icon icon-" + item.icon);
+                        $t.addClass("context-menu-icon context-menu-icon-" + item.icon);
                     }
                 }
                 


### PR DESCRIPTION
I have tried to integrate jQuery-contextMenu plugin with Twitter Bootstrap and have got a problem with items, to which icons are added (only 3 items Edit, Cut and Quit have icons.)
    The issue is 2 fold:
1. Unless there is a separator, items become inline and
2. Their highlight and click area becomes about 10-20 pixels wide

     To demonstrate please see this screenshot:http://tinker.alexey.vassiliev.com.ua/wp-content/uploads/2012/09/contextMenuProblemShow.png

     The issue can be reproduced with files in commit 58da4a7fc450e4320a33f04c35a0a5118874e56e (https://github.com/vaal12/jQuery-contextMenu/commit/58da4a7fc450e4320a33f04c35a0a5118874e56e)
     from repository https://github.com/vaal12/jQuery-contextMenu.git (local file in browser: bootstrap_example\index.html)

     What I found to be a culprit of the issue is css class "icon" added to menu items and it is being conflicted with some class of bootstrap library. So proposed changes are to change this in jquery.contextMenu.js and corresponding entries in jquery.contextMenu.css to "context-menu-icon".

     Result can be seen here: http://tinker.alexey.vassiliev.com.ua/wp-content/uploads/2012/09/bootstrap_problem_resolved.png