### PR TITLE
removed e.stopPropagation call in keyStop function

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -426,8 +426,6 @@ var // currently active contextMenu trigger
             if (!opt.isInput) {
                 e.preventDefault();
             }
-            
-            e.stopPropagation();
         },
         key: function(e) {
             var opt = $currentTrigger.data('contextMenu') || {},


### PR DESCRIPTION
Hi, first of all I want thank you for good library :).
I am using it in my application and sometime I need to check
is Esc-button presed and do some processing. But becaouse of
stopPropagation function I could not to know about it.
Is it realy necessary? Can we just drop it?
Or exclude in some situations?
