### PR TITLE
Exported all internal event handlers

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1581,5 +1581,6 @@ $.contextMenu.fromMenu = function(element) {
 // make defaults accessible
 $.contextMenu.defaults = defaults;
 $.contextMenu.types = types;
+$.contextMenu.handle = handle;
 
 })(jQuery);


### PR DESCRIPTION
Exported all internal event handlers to allow access 
the otherwise opaque handlers from the outside:

```
$.contextMenu.handle.keyStop = $.noop;
```

https://github.com/medialize/jQuery-contextMenu/pull/98
