### PR TITLE
fix the position when menu's css has a padding-top and padding-bottom

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -128,11 +128,11 @@ var // currently active contextMenu trigger
             // correct offset if viewport demands it
             var bottom = $win.scrollTop() + $win.height(),
                 right = $win.scrollLeft() + $win.width(),
-                height = opt.$menu.height(),
-                width = opt.$menu.width();
+                height = opt.$menu.outerHeight(),
+                width = opt.$menu.outerWidth();
             
             if (offset.top + height > bottom) {
-                offset.top -= height;
+                offset.top = bottom - height - 10;
             }
             
             if (offset.left + width > right) {


### PR DESCRIPTION
If I add a padding-top and padding-bottom to .context-menu-list, the contextmenu position is wrong.