### PR TITLE
Show CSS icons on HTML5 Polyfill

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1556,7 +1556,8 @@ function menuChildren(items, $children, counter) {
                         item = {
                             name: $node.attr('label'),
                             disabled: !!$node.attr('disabled'),
-                            callback: (function(){ return function(){ $node.click(); }; })()
+                            callback: (function(){ return function(){ $node.click(); }; })(),
+                            icon: $node.is('[icon]') ? $node.attr('icon').replace(/^.*[\\\/]/, '').replace(/\..*$/, '') : undefined
                         };
                         break;
                         


### PR DESCRIPTION
Based on icon attribute of command element. This attribute contains icon path so use extracted file name without extension as an icon class (e.g. "images/cut.png" becomes "cut").