### PR TITLE
Added preserveState option to prevent resetting of menu item states

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -176,6 +176,8 @@ var // currently active contextMenu trigger
         },
         // default callback
         callback: null,
+		// maintain state of items (disabled, checked inputs, etc) between menu appearances
+		preserveState: false,
         // list of contextMenu items
         items: {}
     },
@@ -1140,6 +1142,9 @@ var // currently active contextMenu trigger
                 root = opt;
                 op.resize(opt.$menu);
             }
+			if (opt.preserveState) {
+				return;
+			}
             // re-check disabled for each item
             opt.$menu.children().each(function(){
                 var $item = $(this),


### PR DESCRIPTION
Every time a menu opens, its items are refreshed with their original state: items are re-disabled (or enabled), checkbox and radio "checked" properties are reset, text inputs are emptied. I added a "preserveState" menu option that skips these resets.

I'm using this with filters for table data. Each menu is a list of checkboxes that add criteria to the filter. When the user opens the menu, she should see controls that match the current filters. I did not want to have to modify each menu's options.items object with every change.
