### PR TITLE
Fixed that menu items were executed on right-click

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1304,7 +1304,7 @@ $.contextMenu = function(operation, options) {
                     }, '.context-menu-list')
                     .on('mouseup.contextMenu', '.context-menu-input', handle.inputClick)
                     .on({
-                        'mouseup.contextMenu': handle.itemClick,
+                        'click.contextMenu': handle.itemClick,
                         'contextmenu:focus.contextMenu': handle.focusItem,
                         'contextmenu:blur.contextMenu': handle.blurItem,
                         'contextmenu.contextMenu': handle.abortevent,


### PR DESCRIPTION
Right-click to open menu, then hover any inner item and right-click it - item will be called/executed. IMHO it shouldn't do anything unless you left-click item. I wouldn't care much, but I've got a combination of problems on Chrome on Mac: when I right-click to open contextMenu it is positioned right under the mouse (not near) then the *same* right-click event is passed to the first item (because the mouse is over it) and it is executed immediately.
I don't know, maybe there were reasons to use onmouseup. But please consider to use onclick again :)

P.S. The 2nd minor reason not to over-use right-click - to not prevent me (as a developer) to get to browser context menu (particularly to "Inspect element"). I "fixed" that for contextMenu itself by not showing it when I hold Ctrl when right-clicking, and that didn't force me to modify your code. But I think it's hard to workaround such for right-click on an menu item.

Thank you for a good job! :)