### PR TITLE
Default Menu Item Text to Black

### DIFF
--- a/src/jquery.contextMenu.css
+++ b/src/jquery.contextMenu.css
@@ -36,6 +36,7 @@
 }
 
 .context-menu-item {
+    color: #000;
     padding: 2px 2px 2px 24px;
     background-color: #EEE;
     position: relative;


### PR DESCRIPTION
The background is light grey, and in one of my sites the default text
color is white. This looked bad in the menu. Since the menu is supposed
to be general purpose, I believe this should be fixed in the core CSS.