### PR TITLE
Hide menu even if mouse down happens in another window (eg. iFrame)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 node_modules/
+.idea
+bower_components

--- a/demo/disabled-changing_test.html
+++ b/demo/disabled-changing_test.html
@@ -44,14 +44,21 @@
 
     <h2 id="demo">Demo: Changing Disabled</h2>
     <div class="inline-spaces">
-<div class="context-menu-one box menu-1">
-    <strong>right click me</strong>
-</div>
+        <div class="context-menu-one box menu-1">
+            <strong>right click me</strong>
+        </div>
     </div>
+
+        <button id="hide">Hide</button>
 
     <h3 id="code">Example code: Changing Disabled</h3>
     <script type="text/javascript" class="showcase">
 $(function(){
+
+    $('#hide').click(function(){
+        jQuery('.context-menu-one').contextMenu("hide");
+    });
+
     $.contextMenu({
         selector: '.context-menu-one', 
         callback: function(key, options) {
@@ -80,6 +87,9 @@ $(function(){
     });
 });
     </script>
+
+
+
 
     <h3 id="html">Example HTML: Changing Disabled</h3>
     <div style="display:none" class="showcase" data-showcase-import=".menu-1"></div>
@@ -120,5 +130,6 @@ $(function(){
     </ul>
     </div>
     <div id="msg"></div>
+
 </body>
 </html>

--- a/demo/iframe.html
+++ b/demo/iframe.html
@@ -44,7 +44,7 @@
 
     <h2 id="demo">Demo: Root document</h2>
     <div class="inline-spaces">
-        <div class="context-menu-root box menu-1">
+        <div id="activate-menu" class="box menu-1">
             <strong>right click me</strong>
         </div>
     </div>
@@ -55,11 +55,8 @@
     <h3 id="code">Example code: iFrames</h3>
     <script type="text/javascript" class="showcase">
         $(function(){
-            /**************************************************
-             * Context-Menu with Sub-Menu
-             **************************************************/
             $.contextMenu({
-                selector: '.context-menu-root',
+                selector: '#activate-menu',
                 callback: function(key, options) {
                     var m = "clicked: " + key;
                     window.console && console.log(m) || alert(m);
@@ -68,8 +65,7 @@
                     "edit": {"name": "Edit", "icon": "edit"},
                     "cut": {"name": "Cut", "icon": "cut"},
                     "sep1": "---------",
-                    "quit": {"name": "Quit", "icon": "quit"},
-                    "sep2": "---------"
+                    "quit": {"name": "Quit", "icon": "quit"}
                 }
             });
         });

--- a/demo/iframe.html
+++ b/demo/iframe.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="de" lang="de">
 <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE8" />
     <meta charset="utf-8" />
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <title>Sub Menus Demo - jQuery contextMenu Plugin</title>

--- a/demo/iframe.html
+++ b/demo/iframe.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="de" lang="de">
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <title>Sub Menus Demo - jQuery contextMenu Plugin</title>
+    <meta name="description" content="simple contextMenu generator for interactive web applications based on jQuery" />
+
+    <script src="../jquery-1.8.2.min.js" type="text/javascript"></script>
+    <script src="../src/jquery.ui.position.js" type="text/javascript"></script>
+    <script src="../src/jquery.contextMenu.js" type="text/javascript"></script>
+    <script src="../prettify/prettify.js" type="text/javascript"></script>
+    <script src="../screen.js" type="text/javascript"></script>
+
+    <link href="../src/jquery.contextMenu.css" rel="stylesheet" type="text/css" />
+    <link href="../screen.css" rel="stylesheet" type="text/css" />
+    <link href="../prettify/prettify.sunburst.css" rel="stylesheet" type="text/css" />
+
+    <script type="text/javascript">
+
+        var _gaq = _gaq || [];
+        _gaq.push(['_setAccount', 'UA-8922143-3']);
+        _gaq.push(['_trackPageview']);
+
+        (function() {
+            var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+            ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+            var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+        })();
+
+    </script>
+</head>
+<body>
+<a id="github-forkme" href="https://github.com/medialize/jQuery-contextMenu"><img src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
+<div id="container">
+    <h1><a href="https://github.com/medialize/jQuery-contextMenu">jQuery contextMenu</a></h1>
+
+    <ul class="menu">
+        <li><a href="../index.html">About</a></li>
+        <li class="active"><a href="../demo.html">Demo</a></li>
+        <li><a href="../docs.html">Documentation</a></li>
+        <li><a href="http://rodneyrehm.de/en/">Author</a></li>
+    </ul>
+
+    <h2 id="demo">Demo: Root document</h2>
+    <div class="inline-spaces">
+        <div class="context-menu-root box menu-1">
+            <strong>right click me</strong>
+        </div>
+    </div>
+
+    <iframe id="frame1" border="0" style="border: none; overflow: hidden; width: 100%; height: 150px; background-color: #ffffff;" src="iframe1.html"></iframe>
+    <iframe id="frame2" border="0" style="border: none; overflow: hidden; width: 100%; height: 150px; background-color: #ffffff;" src="iframe2.html"></iframe>
+
+    <h3 id="code">Example code: iFrames</h3>
+    <script type="text/javascript" class="showcase">
+        $(function(){
+            /**************************************************
+             * Context-Menu with Sub-Menu
+             **************************************************/
+            $.contextMenu({
+                selector: '.context-menu-root',
+                callback: function(key, options) {
+                    var m = "clicked: " + key;
+                    window.console && console.log(m) || alert(m);
+                },
+                items: {
+                    "edit": {"name": "Edit", "icon": "edit"},
+                    "cut": {"name": "Cut", "icon": "cut"},
+                    "sep1": "---------",
+                    "quit": {"name": "Quit", "icon": "quit"},
+                    "sep2": "---------"
+                }
+            });
+        });
+    </script>
+
+
+
+    <h3 id="html">Example HTML: iFrames</h3>
+    <div style="display:none" class="showcase" data-showcase-import=".menu-1"></div>
+
+
+    <h2>jQuery Context Menu Demo Gallery</h2>
+    <ul id="demo-list">
+        <li><a href="../demo.html">Simple Context Menu</a></li>
+        <li><a href="on-dom-element.html">Context Menu on DOM Element</a></li>
+        <li><a href="dynamic.html">Adding new Context Menu Triggers</a></li>
+        <li><a href="dynamic-create.html">Create Context Menu on demand</a></li>
+        <li><a href="async-create.html">Create Context Menu (asynchronous)</a></li>
+
+        <li><a href="keeping-contextmenu-open.html">Keeping the context menu open</a></li>
+        <li><a href="callback.html">Command's action (callbacks)</a></li>
+
+        <li><a href="trigger-left-click.html">Left-Click Trigger</a></li>
+        <li><a href="trigger-swipe.html">Swipe Trigger</a></li>
+        <li><a href="trigger-hover.html">Hover Activated Context Menu</a></li>
+        <li><a href="trigger-hover-autohide.html">Hover Activated Context Menu With Autohide</a></li>
+        <li><a href="trigger-custom.html">Custom Activated Context Menu</a></li>
+
+        <li><a href="disabled-menu.html">Disabled Menu</a></li>
+        <li><a href="disabled.html">Disabled Command</a></li>
+        <li><a href="disabled-callback.html">Disabled Callback Command</a></li>
+        <li><a href="disabled-changing.html">Changing Command's disabled status</a></li>
+
+        <li><a href="accesskeys.html">Accesskeys</a></li>
+        <li class="current"><a href="sub-menus.html">Submenus</a></li>
+
+        <li><a href="input.html">Input Commands</a></li>
+        <li><a href="custom-command.html">Custom Command Types</a></li>
+
+        <li><a href="menu-title.html">Menus with titles</a></li>
+
+        <li><a href="html5-import.html">Importing HTML5 &lt;menu type=&quot;context&quot;&gt;</a></li>
+        <li><a href="html5-polyfill.html">HTML5 Polyfill</a></li>
+        <li><a href="html5-polyfill-firefox8.html">HTML5 Polyfill (Firefox 8)</a></li>
+    </ul>
+</div>
+</body>
+</html>

--- a/demo/iframe1.html
+++ b/demo/iframe1.html
@@ -25,9 +25,6 @@
 
     <script type="text/javascript">
         $(function(){
-            /**************************************************
-             * Context-Menu with Sub-Menu
-             **************************************************/
             $.contextMenu({
                 selector: '.context-menu-iframe1',
                 callback: function(key, options) {
@@ -38,8 +35,7 @@
                     "edit": {"name": "Edit", "icon": "edit"},
                     "cut": {"name": "Cut", "icon": "cut"},
                     "sep1": "---------",
-                    "quit": {"name": "Quit", "icon": "quit"},
-                    "sep2": "---------"
+                    "quit": {"name": "Quit", "icon": "quit"}
                 }
             });
         });

--- a/demo/iframe1.html
+++ b/demo/iframe1.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="de" lang="de">
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <title>Sub Menus Demo - jQuery contextMenu Plugin</title>
+    <meta name="description" content="simple contextMenu generator for interactive web applications based on jQuery" />
+
+    <script src="../jquery-1.8.2.min.js" type="text/javascript"></script>
+    <script src="../src/jquery.ui.position.js" type="text/javascript"></script>
+    <script src="../src/jquery.contextMenu.js" type="text/javascript"></script>
+    <script src="../prettify/prettify.js" type="text/javascript"></script>
+    <script src="../screen.js" type="text/javascript"></script>
+
+    <link href="../src/jquery.contextMenu.css" rel="stylesheet" type="text/css" />
+    <link href="../screen.css" rel="stylesheet" type="text/css" />
+    <link href="../prettify/prettify.sunburst.css" rel="stylesheet" type="text/css" />
+
+</head>
+<body style="background-color: #ffffff;">
+
+    <div class="context-menu-iframe1 box menu-1">
+        <strong>right click me (iFrame 1)</strong>
+    </div>
+
+    <script type="text/javascript">
+        $(function(){
+            /**************************************************
+             * Context-Menu with Sub-Menu
+             **************************************************/
+            $.contextMenu({
+                selector: '.context-menu-iframe1',
+                callback: function(key, options) {
+                    var m = "clicked: " + key;
+                    window.console && console.log(m) || alert(m);
+                },
+                items: {
+                    "edit": {"name": "Edit", "icon": "edit"},
+                    "cut": {"name": "Cut", "icon": "cut"},
+                    "sep1": "---------",
+                    "quit": {"name": "Quit", "icon": "quit"},
+                    "sep2": "---------"
+                }
+            });
+        });
+    </script>
+
+
+
+
+</div>
+</body>
+</html>

--- a/demo/iframe2.html
+++ b/demo/iframe2.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="de" lang="de">
+<head>
+    <meta charset="utf-8" />
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <title>Sub Menus Demo - jQuery contextMenu Plugin</title>
+    <meta name="description" content="simple contextMenu generator for interactive web applications based on jQuery" />
+
+    <script src="../jquery-1.8.2.min.js" type="text/javascript"></script>
+    <script src="../src/jquery.ui.position.js" type="text/javascript"></script>
+    <script src="../src/jquery.contextMenu.js" type="text/javascript"></script>
+    <script src="../prettify/prettify.js" type="text/javascript"></script>
+    <script src="../screen.js" type="text/javascript"></script>
+
+    <link href="../src/jquery.contextMenu.css" rel="stylesheet" type="text/css" />
+    <link href="../screen.css" rel="stylesheet" type="text/css" />
+    <link href="../prettify/prettify.sunburst.css" rel="stylesheet" type="text/css" />
+
+</head>
+<body style="background-color: #ffffff;">
+
+<div class="context-menu-iframe2 box menu-1">
+    <strong>right click me (iFrame 2)</strong>
+</div>
+
+<script type="text/javascript">
+    $(function(){
+        /**************************************************
+         * Context-Menu with Sub-Menu
+         **************************************************/
+        $.contextMenu({
+            selector: '.context-menu-iframe2',
+            callback: function(key, options) {
+                var m = "clicked: " + key;
+                window.console && console.log(m) || alert(m);
+            },
+            items: {
+                "edit": {"name": "Edit", "icon": "edit"},
+                "cut": {"name": "Cut", "icon": "cut"},
+                "sep1": "---------",
+                "quit": {"name": "Quit", "icon": "quit"},
+                "sep2": "---------"
+            }
+        });
+    });
+</script>
+
+
+</div>
+</body>
+</html>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,13 +16,12 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
 
-      // dependencies
-      { pattern: 'jquery-1.8.2.min.js', watched: false, served: true, included: true },
-      { pattern: 'src/jquery.ui.position.js', watched: false, served: true, included: true },
-      { pattern: 'src/jquery.contextMenu.js', watched: false, served: true, included: true },
-
-      // test modules
-      'test/unit/*.js'
+        // dependencies
+        { pattern: 'jquery-1.8.2.min.js', watched: false, served: true, included: true },
+        { pattern: 'src/jquery.ui.position.js', watched: false, served: true, included: true },
+        { pattern: 'src/jquery.contextMenu.js', watched: false, served: true, included: true },
+        // test modules
+        'test/unit/*.js'
     ],
 
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "karma-chrome-launcher": "^0.1.5",
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-qunit": "^0.1.4",
-    "qunitjs": "^1.15.0"
+    "qunitjs": "^1.15.0" 
   },
   "description": "Management facility for context menus. Developed for a large number of triggering objects. HTML5 Polyfill",
   "keywords": [

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -646,7 +646,6 @@ var // currently active contextMenu trigger
         },
         // contextMenu item click
         itemClick: function(e) {
-            console.log('item click');
             var $this = $(this),
                 data = $this.data(),
                 opt = data.contextMenu,
@@ -802,28 +801,7 @@ var // currently active contextMenu trigger
                 .removeData('contextMenu')
                 .removeClass("context-menu-active");
             
-            //if (opt.$layer) {
-            //    // keep layer for a bit so the contextmenu event can be aborted properly by opera
-            //    setTimeout((function($layer) {
-            //        return function(){
-            //            $layer.remove();
-            //        };
-            //    })(opt.$layer), 10);
-            //
-            //    try {
-            //        delete opt.$layer;
-            //    } catch(e) {
-            //        opt.$layer = null;
-            //    }
-            //}
 
-            //$(window.document).off('mousedown');
-            //
-            //$(window.document).on('contextmenu', null, function () {
-            //    //handle.abortevent
-            //    window.top.postMessage("DOMEVENT-CONTEXTMENU", "*");
-            //    console.log("Posted DOMEVENT-CONTEXTMENU from the context menu.");
-            //});
             
             // remove handle
             $currentTrigger = null;
@@ -860,6 +838,8 @@ var // currently active contextMenu trigger
                     $trigger.trigger('contextmenu:hidden');
                 }, 10);
             });
+
+
         },
         create: function(opt, root) {
             if (root === undefined) {
@@ -1127,38 +1107,8 @@ var // currently active contextMenu trigger
                     op.update.call($trigger, item, root);
                 }
             });
-        },
-        // function(opt, zIndex) {
-        //    //add transparent layer for click area
-        //    //filter and background for Internet Explorer, Issue #23
-        //    //var $layer = opt.$layer = $('<div id="context-menu-layer" style="position:fixed; z-index:' + zIndex + '; top:0; left:0; opacity: 0; filter: alpha(opacity=0); background-color: #000;"></div>')
-        //    //    .css({height: $win.height(), width: $win.width(), display: 'block'})
-        //    //    .data('contextMenuRoot', opt)
-        //    //    .insertBefore(this)
-        //    //    .on('contextmenu', handle.abortevent)
-        //    //    .on('mousedown', handle.layerClick);
-        //
-        //    //var $layer = opt.$layer = $('<div id="context-menu-layer" style="position:fixed; z-index:' + zIndex + '; top:0; left:0; opacity: 0; filter: alpha(opacity=0); background-color: #000; pointer-events: none; background: none !important"></div>')
-        //    //    .css({height: $win.height(), width: $win.width(), display: 'block'})
-        //    //    .data('contextMenuRoot', opt)
-        //    //    .insertBefore(this)
-        //    //    .on('contextmenu', handle.abortevent)
-        //    //    .on('mousedown', handle.layerClick);
-        //
-        //
-        //    // IE6 doesn't know position:fixed;
-        //    //if (!$.support.fixedPosition) {
-        //    //    $layer.css({
-        //    //        'position' : 'absolute',
-        //    //        'height' : $(document).height()
-        //    //    });
-        //    //}
-        //
-        //    //Post dom events to the top window so that we know when to close context menus in any iFrame.
-        //
-        //
-        //    //return $layer;
-        //}
+        }
+
     };
 
 // split accesskey according to http://www.whatwg.org/specs/web-apps/current-work/multipage/editing.html#assigned-access-key
@@ -1183,8 +1133,10 @@ $.fn.contextMenu = function(operation) {
     } else if (operation.x && operation.y) {
         this.first().trigger($.Event("contextmenu", {pageX: operation.x, pageY: operation.y}));
     } else if (operation === "hide") {
-        var $menu = this.data('contextMenu').$menu;
-        $menu && $menu.trigger('contextmenu:hide');
+        if (this.data('contextMenu')) {
+            var $menu = this.data('contextMenu').$menu;
+            $menu && $menu.trigger('contextmenu:hide');
+        }
     } else if (operation === "destroy") {
         $.contextMenu("destroy", {context: this});
     } else if ($.isPlainObject(operation)) {
@@ -1278,7 +1230,8 @@ $.contextMenu = function(operation, options) {
                     $this = $(this);
                     $target = $(event.target);
 
-                    if ($target.parents('.context-menu-item').length)
+                    //We not interested to hide ourselves for clicks on menu items. This is handled elsewhere.
+                    if ($target.hasClass('context-menu-item') || $target.parents('.context-menu-item').length)
                     {
                         return;
                     }
@@ -1291,16 +1244,16 @@ $.contextMenu = function(operation, options) {
 
                     //Post a message to the top window so that any other context menus in any other iFrames can also close.
                     window.top.postMessage("JQCM-DOMEVENT-MOUSEDOWN", "*");
-                    console.log("Posted JQCM-DOMEVENT-MOUSEDOWN from the context menu.");
+                    //console.log("Posted JQCM-DOMEVENT-MOUSEDOWN from the context menu.");
                 });
 
                 //Handle messages so that context menus on this page are hidden if we get a mouse down in any other iFrame
                 window.top.addEventListener("message", function (event) {
-                    console.log('Handle message from the top window in the context menu');
-
-                    console.log('Origin: ' + event.origin);
-                    console.log('Data: ' + event.data);
-                    console.log('Source: ' + event.source);
+                    //console.log('Handle message from the top window in the context menu');
+                    //
+                    //console.log('Origin: ' + event.origin);
+                    //console.log('Data: ' + event.data);
+                    //console.log('Source: ' + event.source);
 
                     if (event.data !== 'JQCM-DOMEVENT-MOUSEDOWN')
                     {

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1228,7 +1228,7 @@ $.contextMenu = function(operation, options) {
                 //Global mouse down so that we can hide the menu in other iframes
                 $(document).on('mousedown.contextMenu.global', null, function(e) {
                     $this = $(this);
-                    $target = $(event.target);
+                    $target = $(e.target);
 
                     //We not interested to hide ourselves for clicks on menu items. This is handled elsewhere.
                     if ($target.hasClass('context-menu-item') || $target.parents('.context-menu-item').length)
@@ -1241,14 +1241,24 @@ $.contextMenu = function(operation, options) {
                         $currentTrigger.data('contextMenu').$menu.trigger('contextmenu:hide');
                     }
 
-
                     //Post a message to the top window so that any other context menus in any other iFrames can also close.
                     window.top.postMessage("JQCM-DOMEVENT-MOUSEDOWN", "*");
                     //console.log("Posted JQCM-DOMEVENT-MOUSEDOWN from the context menu.");
                 });
 
+                function addEvent(evnt, elem, func) {
+                    if (elem.addEventListener)  // W3C DOM
+                        elem.addEventListener(evnt,func,false);
+                    else if (elem.attachEvent) { // IE DOM
+                        elem.attachEvent("on"+evnt, func);
+                    }
+                    else { // No much to do
+                        elem[evnt] = func;
+                    }
+                }
+
                 //Handle messages so that context menus on this page are hidden if we get a mouse down in any other iFrame
-                window.top.addEventListener("message", function (event) {
+               addEvent("message",  window.top, function (event) {
                     //console.log('Handle message from the top window in the context menu');
                     //
                     //console.log('Origin: ' + event.origin);
@@ -1266,7 +1276,7 @@ $.contextMenu = function(operation, options) {
                     }
 
 
-                    console.log('Hide our context menu');
+                    //console.log('Hide our context menu');
 
                     // We should hide ourselves as a click happened in another window.
                     if ($currentTrigger && $currentTrigger.length) {

--- a/test/integration/disabled-changing.js
+++ b/test/integration/disabled-changing.js
@@ -28,6 +28,7 @@ module.exports = {
       .click('.context-menu-root li:nth-child(3)')
       .assert.doesntExist('.context-menu-root .disabled', 'All menu items are enabled')
       .click('.context-menu-root li:nth-child(2)')
+      .wait(100)
       .assert.text('#msg', 'clicked: cut', 'Enabled menu item sets text')
       .done();
   },

--- a/test/integration/disabled-changing.js
+++ b/test/integration/disabled-changing.js
@@ -10,7 +10,6 @@ module.exports = {
     test
       .open('file://' + pwd + '/demo/disabled-changing_test.html')
       .execute(helper.rightClick, '.context-menu-one')
-      .waitForElement('#context-menu-layer')
       .wait(100)
       .assert.numberOfElements('.context-menu-root li')
         .is(3, '3 context menu items are shown')
@@ -23,12 +22,18 @@ module.exports = {
     test
       .open('file://' + pwd + '/demo/disabled-changing_test.html')
       .execute(helper.rightClick, '.context-menu-one')
-      .waitForElement('#context-menu-layer')
       .wait(100)
+      .assert.exists('.context-menu-root .disabled', 'At least one menu item is disabled')
       .click('.context-menu-root li:nth-child(3)')
+        .execute(helper.rightClick, '.context-menu-one')
+        .wait(100)
       .assert.doesntExist('.context-menu-root .disabled', 'All menu items are enabled')
       .click('.context-menu-root li:nth-child(2)')
-      .wait(100)
+        .wait(100)
+      .log.dom('#msg')
+        //.log.message(function() {
+        //    return jQuery('#msg').text();
+        //})
       .assert.text('#msg', 'clicked: cut', 'Enabled menu item sets text')
       .done();
   },
@@ -39,12 +44,12 @@ module.exports = {
       .execute(helper.rightClick, '.context-menu-one')
       .waitForElement('#context-menu-layer')
       .wait(100)
+      .assert.exists('.context-menu-root .disabled', 'At least one menu item is disabled')
       .click('.context-menu-root li:nth-child(3)')
       .assert.doesntExist('.context-menu-root .disabled', 'All menu items are enabled')
       .execute(helper.closeMenu, '.context-menu-one')
       .wait(100)
       .execute(helper.rightClick, '.context-menu-one')
-      .waitForElement('#context-menu-layer')
       .wait(100)
       .assert.doesntExist('.context-menu-root .disabled', 'All menu items are still enabled')
       .done();

--- a/test/integration/iframe.js
+++ b/test/integration/iframe.js
@@ -1,0 +1,51 @@
+var pwd = process.cwd();
+var helper = require('../integration_test_helper.js');
+
+module.exports = {
+    'Click in outside the menu on the body closes the menu': function (test) {
+        test
+            .open('file://' + pwd + '/demo/iframe.html')
+            .execute(helper.rightClick, '#activate-menu')
+            .assert.exists('.context-menu-root', 'It opens context menu')
+            .assert.visible('.context-menu-root', 'It opens context menu')
+            .assert.numberOfElements('.context-menu-root li')
+            .is(4, '4 context menu items are shown')
+            .click('body')
+            .wait(100)
+            .assert.notVisible('.context-menu-root', 'Click outside closes context menu')
+            .done();
+    },
+    'Click in another iframe on the body closes the menu': function (test) {
+        test
+            .open('file://' + pwd + '/demo/iframe.html')
+            .execute(helper.rightClick, '#activate-menu')
+            .assert.exists('.context-menu-root', 'The context menu exists')
+            .assert.visible('.context-menu-root', 'It opens context menu')
+            .assert.numberOfElements('.context-menu-root li')
+            .is(4, '4 context menu items are shown')
+            .toFrame('#frame1')
+                .click('body')
+            .toParent()
+            .wait(100)
+            .assert.notVisible('.context-menu-root', 'Click in the iframe closes the menu')
+            .done();
+    },
+    'Right click in another iframe on the body closes the top menu and shows the menu in the iframe': function (test) {
+        test
+            .open('file://' + pwd + '/demo/iframe.html')
+            .execute(helper.rightClick, '#activate-menu')
+            .assert.exists('.context-menu-root', 'It opens context menu')
+            .assert.visible('.context-menu-root', 'It opens context menu')
+            .assert.numberOfElements('.context-menu-root li')
+            .is(4, '4 context menu items are shown')
+            .toFrame('#frame1')
+                .execute(helper.rightClick, '.context-menu-iframe1', 'mousedown')  //Mouse down should happen first
+                .execute(helper.rightClick, '.context-menu-iframe1') //Then context menu
+                .assert.exists('.context-menu-root', 'The context menu in the iframe exists')
+                .assert.visible('.context-menu-root', 'The context menu in the iframe is visible')
+            .toParent()
+            .wait(100)
+            .assert.notVisible('.context-menu-root', 'Right click in the iframe closes the menu')
+            .done();
+    }
+};

--- a/test/integration/keeping-contextmenu-open.js
+++ b/test/integration/keeping-contextmenu-open.js
@@ -22,7 +22,7 @@ module.exports = {
       .wait(100)
       .assert.visible('.context-menu-root li:first-child', 'Menu item is present')
       .click('.context-menu-root li:first-child')
-      .assert.doesntExist('#context-menu-layer', 'It closes context menu')
+      .assert.notVisible('.context-menu-root', 'Menu item is hidden')
       .done();
   },
 
@@ -34,7 +34,7 @@ module.exports = {
       .wait(100)
       .assert.visible('.context-menu-root', 'Menu is present')
       .click('.context-menu-root li:last-child')
-      .assert.exists('#context-menu-layer', 'It closes context menu')
+      .assert.visible('.context-menu-root', 'Menu is still visible')
       .done();
   }
 };

--- a/test/integration/on-dom-element.js
+++ b/test/integration/on-dom-element.js
@@ -6,7 +6,6 @@ module.exports = {
     test
       .open('file://' + pwd + '/demo/on-dom-element.html')
       .execute(helper.rightClick, '#the-node li:first-child')
-      .waitForElement('#context-menu-layer')
       .assert.exists('.context-menu-root', 'It opens context menu')
       .assert.numberOfElements('.context-menu-root li')
         .is(7, '7 context menu items are shown')
@@ -16,7 +15,6 @@ module.exports = {
       // right click on the other DOM element
       .execute(helper.rightClick, '#the-node li:nth-child(3)')
       .wait(100) // wait for the old menu to close and new to reopen
-      .waitForElement('#context-menu-layer')
       .assert.exists('.context-menu-root', 'It re-opens the same context menu')
       .assert.numberOfElements('.context-menu-active')
         .is(1, 'ensure still only one context menu is open')


### PR DESCRIPTION
I thought this could be useful to others so created a pull request.

I used the window.top.postMessage to basically notify any other open menus that a mouse down has occurred in another window so any open context menu can close itself.

I also did not want the overlay and took it out so that clicks can still select items underneath.

There seems to be an issue with Dalek visible and notVisible so two of the tests are broken.
