### PR TITLE
Update package.json to set jquery dep as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "http://www.swis.nl"
   },
   "license": "MIT",
-  "dependencies": {
+  "peerDependencies": {
     "jquery": "^1.8.2"
   },
   "devDependencies": {


### PR DESCRIPTION
I'm having some issues of duplicated jQuery instances when using jQuery contextMenu with npm 3.x. This works great when jQuery is declared as a peer dependency (and this is the recommended declaration of dependencies for plugins).