### PR TITLE
Properly fixed the problem with submenus size wrongly

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1236,7 +1236,7 @@
                 // determine width of absolutely positioned element
                 $menu.css({position: 'absolute', display: 'block'});
                 // don't apply yet, because that would break nested elements' widths
-                $menu.data('width', Math.ceil($menu.width()));
+                $menu.data('width', Math.ceil($menu.outerWidth()));
                 // reset styles so they allow nested elements to grow/shrink naturally
                 $menu.css({
                     position: 'static',

--- a/src/sass/jquery.contextMenu.scss
+++ b/src/sass/jquery.contextMenu.scss
@@ -31,7 +31,6 @@
   min-width: $context-menu-min-width;
   padding: $context-menu-container-padding;
   position: absolute;
-  white-space: pre;
 }
 
 .context-menu-item {


### PR DESCRIPTION
Using the css code i made before was wrong. I found out that if you changed the $menu.width() to $menu.outerWidth() it would get the correct size.

This pull request can close the issue #308 problem solved and fixed.