### PR TITLE
Fixed a swith to use the correct type for seperators

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1111,7 +1111,7 @@
                         }
 
                         switch (item.type) {
-                            case 'seperator':
+                            case 'cm_seperator':
                                 break;
 
                             case 'text':


### PR DESCRIPTION
With this fix you are now able to make a seperator two ways:
1. Old way
"sep1": "----------"
2. like a item where you set the type
"sep2": { "type": "cm_seperator" }

the possible outcome of this is that you can now use the visible function on a seperator that i missed was possible since i make alot of dynamic contextmenus and i did not have to hide the span if i gave the seperator a name. 