### PR TITLE
Positioning of contextmenu when using appendTo

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -332,7 +332,10 @@
                     }
                     if (showMenu) {
                         // show menu
-                        op.show.call($this, e.data, e.pageX, e.pageY);
+		                var menuContainer = (e.data.appendTo === null ? $('body') : $(e.data.appendTo));
+		                op.show.call($this, e.data,
+                					 $(e.srcElement).offset().left - menuContainer.offset().left + e.offsetX,
+                					 $(e.srcElement).offset().top - menuContainer.offset().top + e.offsetY);
                     }
                 }
             },

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -333,9 +333,10 @@
                     if (showMenu) {
                         // show menu
 		                var menuContainer = (e.data.appendTo === null ? $('body') : $(e.data.appendTo));
+		                var srcElement = e.target || e.srcElement || e.originalTarget;
 		                op.show.call($this, e.data,
-                					 $(e.srcElement).offset().left - menuContainer.offset().left + e.offsetX,
-                					 $(e.srcElement).offset().top - menuContainer.offset().top + e.offsetY);
+                					 $(srcElement).offset().left - menuContainer.offset().left + e.offsetX,
+                					 $(srcElement).offset().top - menuContainer.offset().top + e.offsetY);
                     }
                 }
             },


### PR DESCRIPTION
When a selector has been assigned to the appendTo option, the context menu wasn't (always?) positioned at the cursor position.
This fix solves the problem.