### PR TITLE
Made a check to see if target have a heigher zIndex then the …

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -500,29 +500,28 @@
                     opt = $currentTrigger.data('contextMenu') || {};
                 }
                 // If the trigger happen on a element that are above the contextmenu do this
-                if (opt.zIndex == null)
+                if (opt.zIndex === undefined) {
                     opt.zIndex = 0;
+				}
                 var TargetZIndex = 0;
                 var getZIdexOfTriggerTarger = function (target) {
-                    if (target.offsetParent != null) {
-                        if (target.style.zIndex != '')
-                            TargetZIndex = target.style.zIndex;
-                        else {
-							if (target.offsetParent != null) {
-								getZIdexOfTriggerTarger(target.offsetParent);
-							} else {
-								getZIdexOfTriggerTarger(target.parentElement)
-							}
-						}  
-                    }
-                }
+					if (target.style.zIndex !== '') {
+						TargetZIndex = target.style.zIndex;
+					} else {
+						if (target.offsetParent !== null && target.offsetParent !== undefined) {
+							getZIdexOfTriggerTarger(target.offsetParent);
+						} else {
+							getZIdexOfTriggerTarger(target.parentElement);
+						}
+					}
+                };
                 getZIdexOfTriggerTarger(e.target);
                 // If TargetZIndex is heigher then opt.zIndex dont progress any futher. 
                 // This is used to make sure that if you are using a dialog with a input / textarea / contenteditable div
                 // and its above the contextmenu it wont steal keys events
-                if (TargetZIndex > opt.zIndex)
+                if (TargetZIndex > opt.zIndex) {
                     return;
-
+				}
                 switch (e.keyCode) {
                     case 9:
                     case 38: // up

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -499,6 +499,24 @@
                 if ($currentTrigger) {
                     opt = $currentTrigger.data('contextMenu') || {};
                 }
+                // If the trigger happen on a element that are above the contextmenu do this
+                if (opt.zIndex == null)
+                    opt.zIndex = 0;
+                var TargetZIndex = 0;
+                var getZIdexOfTriggerTarger = function (target) {
+                    if (target.offsetParent != null) {
+                        if (target.offsetParent.style.zIndex != '')
+                            TargetZIndex = target.offsetParent.style.zIndex;
+                        else
+                            getZIdexOfTriggerTarger(target.offsetParent);
+                    }
+                }
+                getZIdexOfTriggerTarger(e.target);
+                // If TargetZIndex is heigher then opt.zIndex dont progress any futher. 
+                // This is used to make sure that if you are using a dialog with a input / textarea / contenteditable div
+                // and its above the contextmenu it wont steal keys events
+                if (TargetZIndex > opt.zIndex)
+                    return;
 
                 switch (e.keyCode) {
                     case 9:

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -505,10 +505,15 @@
                 var TargetZIndex = 0;
                 var getZIdexOfTriggerTarger = function (target) {
                     if (target.offsetParent != null) {
-                        if (target.offsetParent.style.zIndex != '')
-                            TargetZIndex = target.offsetParent.style.zIndex;
-                        else
-                            getZIdexOfTriggerTarger(target.offsetParent);
+                        if (target.style.zIndex != '')
+                            TargetZIndex = target.style.zIndex;
+                        else {
+							if (target.offsetParent != null) {
+								getZIdexOfTriggerTarger(target.offsetParent);
+							} else {
+								getZIdexOfTriggerTarger(target.parentElement)
+							}
+						}  
                     }
                 }
                 getZIdexOfTriggerTarger(e.target);

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -510,7 +510,8 @@
 					} else {
 						if (target.offsetParent !== null && target.offsetParent !== undefined) {
 							getZIdexOfTriggerTarger(target.offsetParent);
-						} else {
+						} 
+						else if (target.parentElement !== null && target.parentElement !== undefined) {
 							getZIdexOfTriggerTarger(target.parentElement);
 						}
 					}


### PR DESCRIPTION
…contextmenu in the key event hanlder.

I made this because there was a problem where the contextmenu would steal the key events from a textarea that was in a dialog above the contextmenu. So this is made to see if the target has a zIndex if it dont it tries to find the first offsetparent or parent that have a zIndex and compare this to the contextmenu's zIndex and if the targets zIndex is heigher then it will stop the event handler so that it wont steal key event from the dialog that are above the contextmenu. 