### PR TITLE
Fixed a problem when using the open function

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -339,9 +339,7 @@
                                          $(srcElement).offset().left - menuContainer.offset().left + e.offsetX,
                                          $(srcElement).offset().top - menuContainer.offset().top + e.offsetY);
                         } else {
-                            op.show.call($this, e.data,
-                                         $(srcElement).offset().left - menuContainer.offset().left + e.pageX,
-                                         $(srcElement).offset().top - menuContainer.offset().top + e.pageY);
+                            op.show.call($this, e.data, e.pageX, e.pageY);
                         }
                     }
                 }

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -334,9 +334,15 @@
                         // show menu
 		                var menuContainer = (e.data.appendTo === null ? $('body') : $(e.data.appendTo));
 		                var srcElement = e.target || e.srcElement || e.originalTarget;
-		                op.show.call($this, e.data,
-                					 $(srcElement).offset().left - menuContainer.offset().left + e.offsetX,
-                					 $(srcElement).offset().top - menuContainer.offset().top + e.offsetY);
+                        if (e.offsetX !== undefined && e.offsetY !== undefined) {
+                            op.show.call($this, e.data,
+                                         $(srcElement).offset().left - menuContainer.offset().left + e.offsetX,
+                                         $(srcElement).offset().top - menuContainer.offset().top + e.offsetY);
+                        } else {
+                            op.show.call($this, e.data,
+                                         $(srcElement).offset().left - menuContainer.offset().left + e.pageX,
+                                         $(srcElement).offset().top - menuContainer.offset().top + e.pageY);
+                        }
                     }
                 }
             },


### PR DESCRIPTION
I had a problem where e.offsetX and e.offsetY is undefined. This was mainly when i used the open function like the example below.
`$(selector).contextMenu({ x: ShowX, y: ShowY });`
So i have made a check if they are undefined and if they are pageX and pageY are used instead.