### PR TITLE
Simulate click on the element if the menu already open

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -453,6 +453,7 @@
                     if (document.elementFromPoint && root.$layer) {
                         root.$layer.hide();
                         target = document.elementFromPoint(x - $win.scrollLeft(), y - $win.scrollTop());
+                        $(target).trigger('mousedown').trigger('mouseup');
                         root.$layer.show();
                     }
 


### PR DESCRIPTION
User opens the menu with right click, then he right click again on a different part, contextMenu should inform that "clicked, but hidden by $layer" element about the click event. 

In our system, we have one main contextMenu and our system contains an active item which can be selected by click. If this event not triggered, then the second right click not able to change the active item to the clicked one.