### PR TITLE
replace http://swisnl.github.io with https://swisnl.github.io

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -319,7 +319,7 @@
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo.html
+++ b/demo.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -382,7 +382,7 @@
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/accesskeys.html
+++ b/demo/accesskeys.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -350,7 +350,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/accesskeys_test.html
+++ b/demo/accesskeys_test.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -354,7 +354,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/async-create.html
+++ b/demo/async-create.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -370,7 +370,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/callback.html
+++ b/demo/callback.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -309,19 +309,19 @@
 <script type="text/javascript" class="showcase">
 $(function(){
     $.contextMenu({
-        selector: '.context-menu-one', 
+        selector: '.context-menu-one',
         callback: function(key, options) {
             var m = "global: " + key;
-            window.console && console.log(m) || alert(m); 
+            window.console && console.log(m) || alert(m);
         },
         items: {
             "edit": {
-                name: "Edit", 
-                icon: "edit", 
+                name: "Edit",
+                icon: "edit",
                 // superseeds "global" callback
                 callback: function(key, options) {
                     var m = "edit was clicked";
-                    window.console && console.log(m) || alert(m); 
+                    window.console && console.log(m) || alert(m);
                 }
             },
             "cut": {name: "Cut", icon: "cut"},
@@ -356,7 +356,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/callback_test.html
+++ b/demo/callback_test.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -360,7 +360,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/custom-command.html
+++ b/demo/custom-command.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -399,7 +399,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/custom-command_test.html
+++ b/demo/custom-command_test.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -404,7 +404,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/disabled-callback.html
+++ b/demo/disabled-callback.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -351,7 +351,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/disabled-callback_test.html
+++ b/demo/disabled-callback_test.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -355,7 +355,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/disabled-changing.html
+++ b/demo/disabled-changing.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -358,7 +358,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/disabled-changing_test.html
+++ b/demo/disabled-changing_test.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -362,7 +362,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/disabled-menu.html
+++ b/demo/disabled-menu.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -362,7 +362,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/disabled.html
+++ b/demo/disabled.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -343,7 +343,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/disabled_test.html
+++ b/demo/disabled_test.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -347,7 +347,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/dynamic-create.html
+++ b/demo/dynamic-create.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -355,7 +355,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/dynamic.html
+++ b/demo/dynamic.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -359,7 +359,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/html5-import.html
+++ b/demo/html5-import.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -347,7 +347,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/html5-polyfill-firefox8.html
+++ b/demo/html5-polyfill-firefox8.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -351,7 +351,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/html5-polyfill.html
+++ b/demo/html5-polyfill.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -347,7 +347,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/input.html
+++ b/demo/input.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -427,7 +427,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/keeping-contextmenu-open.html
+++ b/demo/keeping-contextmenu-open.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -351,7 +351,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/menu-title.html
+++ b/demo/menu-title.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -437,7 +437,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/on-dom-element.html
+++ b/demo/on-dom-element.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -358,7 +358,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/sub-menus.html
+++ b/demo/sub-menus.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -372,7 +372,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/sub-menus_test.html
+++ b/demo/sub-menus_test.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -376,7 +376,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/trigger-custom.html
+++ b/demo/trigger-custom.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -358,7 +358,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/trigger-hover-autohide.html
+++ b/demo/trigger-hover-autohide.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -351,7 +351,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/trigger-hover.html
+++ b/demo/trigger-hover.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -350,7 +350,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/trigger-left-click.html
+++ b/demo/trigger-left-click.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -349,7 +349,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/demo/trigger-swipe.html
+++ b/demo/trigger-swipe.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -368,7 +368,7 @@ $(function(){
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/docs.html
+++ b/docs.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -668,7 +668,7 @@ var options = {
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/docs/custom-command-types.html
+++ b/docs/custom-command-types.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -339,7 +339,7 @@ $.contextMenu({
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/docs/customize.html
+++ b/docs/customize.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -329,7 +329,7 @@
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/docs/events.html
+++ b/docs/events.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -374,7 +374,7 @@ $('.context-menu-one').first().trigger("contextmenu");</code></pre>
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/docs/html5-polyfill.html
+++ b/docs/html5-polyfill.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -357,7 +357,7 @@
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/docs/input-helpers.html
+++ b/docs/input-helpers.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -352,7 +352,7 @@
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/docs/items.html
+++ b/docs/items.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -707,7 +707,7 @@
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/docs/plugin-commands.html
+++ b/docs/plugin-commands.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -347,7 +347,7 @@ Unregister contextMenu</code></pre>
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/docs/runtime-options.html
+++ b/docs/runtime-options.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 current">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 current">
                                         <a class="reference internal current"
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -383,7 +383,7 @@
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {

--- a/index.html
+++ b/index.html
@@ -8,18 +8,18 @@
     <link href='https://fonts.googleapis.com/css?family=Lato:400,700,400italic,700italic|Roboto+Slab:400,700|Inconsolata:400,700&subset=latin,cyrillic'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
-    <link rel="stylesheet" href="http://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/screen.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme.css" type="text/css"/>
+    <link rel="stylesheet" href="https://swisnl.github.io/jQuery-contextMenu/css/theme-fixes.css" type="text/css"/>
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
-    <link href="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
+    <link href="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.css" rel="stylesheet" type="text/css" />
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.contextMenu.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/dist/jquery.ui.position.min.js" type="text/javascript"></script>
 
-    <script src="http://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
+    <script src="https://swisnl.github.io/jQuery-contextMenu/js/main.js" type="text/javascript"></script>
 
     <script type="text/javascript">
         var _gaq = _gaq || [];
@@ -42,14 +42,14 @@
 
     <nav data-toggle="wy-nav-shift" class="wy-nav-side">
         <div class="wy-side-nav-search">
-            <a href="http://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/"> jQuery contextMenu</a>
         </div>
 
         <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
             <ul>
                                     <li class="toctree-l1 current">
                         <a class="reference internal current"
-                           href="http://swisnl.github.io/jQuery-contextMenu//">
+                           href="https://swisnl.github.io/jQuery-contextMenu//">
                             Introduction
                         </a>
                                                     <ul>
@@ -61,7 +61,7 @@
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Demo
                                         </a>
                                     </li>
@@ -69,55 +69,55 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                             Documentation
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs.html">
                                             Options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/items.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/items.html">
                                             Defining menu items
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/plugin-commands.html">
                                             Plugin commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/customize.html">
                                             Customize icons
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/runtime-options.html">
                                             Runtime options
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/custom-command-types.html">
                                             Custom command types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/events.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/events.html">
                                             Events
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/docs/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
@@ -125,151 +125,151 @@
                                             </li>
                                     <li class="toctree-l1 ">
                         <a class="reference internal "
-                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                             Demo gallery
                         </a>
                                                     <ul>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo.html">
                                             Simple Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/accesskeys.html">
                                             Accesskeys
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/async-create.html">
                                             Create Context Menu (asynchronous)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/callback.html">
                                             Command's action (callbacks)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/custom-command.html">
                                             Custom Command Types
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled.html">
                                             Disabled Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-callback.html">
                                             Disabled Callback Command
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-changing.html">
                                             Changing Command's disabled status
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/disabled-menu.html">
                                             Disabled Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic.html">
                                             Adding new Context Menu Triggers
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/dynamic-create.html">
                                             Create Context Menu on demand
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-import.html">
                                             Importing HTML5 menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill.html">
                                             HTML5 polyfill
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/html5-polyfill-firefox8.html">
                                             HTML5 polyfill (Firefox)
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/input.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/input.html">
                                             Input Commands
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/keeping-contextmenu-open.html">
                                             Keeping the context menu open
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/menu-title.html">
                                             Menus with titles
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/on-dom-element.html">
                                             Context Menu on DOM Element
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/sub-menus.html">
                                             Submenus
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-custom.html">
                                             Custom Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover.html">
                                             Hover Activated Context Menu
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-hover-autohide.html">
                                             Hover Activated Context Menu With Autohide
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-left-click.html">
                                             Left-Click Trigger
                                         </a>
                                     </li>
                                                                     <li class="toctree-l2 ">
                                         <a class="reference internal "
-                                           href="http://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
+                                           href="https://swisnl.github.io/jQuery-contextMenu/demo/trigger-swipe.html">
                                             Swipe Trigger
                                         </a>
                                     </li>
@@ -278,7 +278,7 @@
                             </ul>
             <div class="swis-branding">
                 <span>Maintained by:</span>
-                <a href="http://www.swis.nl"><img src="http://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
+                <a href="http://www.swis.nl"><img src="https://swisnl.github.io/jQuery-contextMenu/images/swis-logo.jpg" class="swis-logo">Creative Digital Agency</a>
             </div>
         </div>
         &nbsp;
@@ -288,7 +288,7 @@
 
                 <nav class="wy-nav-top" role="navigation" aria-label="top navigation">
             <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
-            <a href="http://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
+            <a href="https://swisnl.github.io/jQuery-contextMenu/">jQuery contextMenu</a>
         </nav>
 
 
@@ -357,7 +357,7 @@
 
 <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
-<script src="http://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
+<script src="https://swisnl.github.io/jQuery-contextMenu/js/theme.js"></script>
 
 <script>
     $(function() {


### PR DESCRIPTION
Since all github pages sites are served over https and http there's no need to hardcode http at all and this will fix mixed content issues on `https://swisnl.github.io/jQuery-contextMenu/index.html`.