### PR TITLE
Bugfix: fixed positioning context menu when used with d3 tree

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -337,13 +337,7 @@
                         // show menu
 		                var menuContainer = (e.data.appendTo === null ? $('body') : $(e.data.appendTo));
 		                var srcElement = e.target || e.srcElement || e.originalTarget;
-                        if (e.offsetX !== undefined && e.offsetY !== undefined) {
-                            op.show.call($this, e.data,
-                                         $(srcElement).offset().left - menuContainer.offset().left + e.offsetX,
-                                         $(srcElement).offset().top - menuContainer.offset().top + e.offsetY);
-                        } else {
-                            op.show.call($this, e.data, e.pageX, e.pageY);
-                        }
+                    op.show.call($this, e.data, e.pageX, e.pageY);
                     }
                 }
             },
@@ -521,7 +515,7 @@
 					} else {
 						if (target.offsetParent !== null && target.offsetParent !== undefined) {
 							getZIndexOfTriggerTarget(target.offsetParent);
-						} 
+						}
 						else if (target.parentElement !== null && target.parentElement !== undefined) {
 							getZIndexOfTriggerTarget(target.parentElement);
 						}


### PR DESCRIPTION
Using jQuery contextMenu with d3 tree (http://bl.ocks.org/mbostock/4339083) object creates a problem with positioning the menu in wrong place.

ContextMenu in opening time checks "offsetX" attribute of event and in case if exists, it does some calculation to position the menu. But in combination with d3 tree, this value will be calculated wrong and menu will be positioned in far right side of page. I have seen in absence of "offsetX" attribute, "pageX" is used. I could fix this issue with replacing the whole condition block with just else part. 
Is there any reason for using offsetX when pageX exists all the time?