### PR TITLE
force font woff2 creation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -130,7 +130,8 @@ gulp.task('build-icons', function () {
             descent: 64,
             normalize: true,
             appendCodepoints: false,
-            startCodepoint: 0xE001
+            startCodepoint: 0xE001,
+			formats: ['ttf', 'eot', 'woff', 'woff2']
         }))
         .on('glyphs', function (glyphs) {
             var options = {


### PR DESCRIPTION
#380 On windows at least, the woff2 font file is not created, and without it, icons are not displayed.