### PR TITLE
Correct typos / mistakes in the main documentation page

### DIFF
--- a/documentation/docs.md
+++ b/documentation/docs.md
@@ -89,7 +89,7 @@ $.contextMenu({
 });
 
 // select the container with a dom element
-var element = document.getElementById('#context-menus-container');
+var element = document.getElementById('context-menus-container');
 $.contextMenu({
     selector: 'span.context-menu',
     appendTo: element
@@ -101,7 +101,7 @@ $.contextMenu({
 
 Specifies what event on the element specified in the [selector](#selector) triggers the contextmenu. 
 
-`appendTo`: `string` default: `'right'` 
+`trigger`: `string` default: `'right'` 
 
 
 Value | Description
@@ -120,7 +120,6 @@ $.contextMenu({
 });
 
 // trigger on hover
-var element = document.getElementById('#context-menus-container');
 $.contextMenu({
     selector: 'span.context-menu',
     trigger: 'hover'


### PR DESCRIPTION
➊ Unlike the jQuery ID selector, the correct syntax for `document.getElementById()` does not use `#` in its argument string.
➋ In the value section of `trigger`, `appendTo `was mistakenly used in place.
➌ In the 2nd example for `trigger`, the first line stores the `context-menus-container` DOM element inside a variable, but it serves no purpose later on.