### PR TITLE
adding option for menu item name to use html() instead of text()

### DIFF
--- a/documentation/docs/items.md
+++ b/documentation/docs/items.md
@@ -59,6 +59,28 @@ var items = {
 ```
 
 
+### isHtmlName
+
+When truthy, the defined `name` value is HTML.
+
+The value will be rendered using `$.html()` instead of `$.text()`.
+
+__Note: Cannot be used with the [accesskey](#accesskey) option in the same item.__
+
+`isHtmlName`: `boolean`
+
+#### Example
+
+```javascript
+var items = {
+    firstCommand: {
+        name: "Copy <span style='font-weight: bold'>Text</span>︎",
+        isHtmlName: true
+    }
+}
+```
+
+
 ### callback 
 
 Specifies the callback to execute if clicked on

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1089,7 +1089,11 @@
                             $name.append(document.createTextNode(item._afterAccesskey));
                         }
                     } else {
-                        $name.text(item.name);
+                        if (item.isHtmlName) {
+                            $name.html(item.name);
+                        } else {
+                            $name.text(item.name);
+                        }
                     }
                     return $name;
                 }

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1090,6 +1090,10 @@
                         }
                     } else {
                         if (item.isHtmlName) {
+                            // restrict use with access keys
+                            if (typeof item.accesskey !== 'undefined') {
+                                throw new Error('accesskeys are not compatible with HTML names and cannot be used together in the same item');
+                            }
                             $name.html(item.name);
                         } else {
                             $name.text(item.name);


### PR DESCRIPTION
After upgrading to 2.x, one thing that has changed since 1.8.1 is the ability to put styled HTML into the names of entries. It is useful to allow for the use of this, even though it could have a potential security risk for dynamically named items.