### PR TITLE
Remove deprecated option in 'bower.json'.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "jQuery-contextMenu",
-  "version": "2.1.1",
   "main": [
     "dist/jquery.contextMenu.js",
     "dist/jquery.contextMenu.min.js",


### PR DESCRIPTION
`version` option is _deprecated_ and is ignored by **Bower**, as mentioned in its [specification](https://github.com/bower/spec/blob/master/json.md#version).