### PR TITLE
Alias for 'cm_seperator' type: 'cm_separator'.

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1112,7 +1112,8 @@
 
                     // Make old school string seperator a real item so checks wont be
                     // akward later.
-                    if (typeof item === 'string') {
+                    // And normalize 'cm_separator' into 'cm_seperator'.
+                    if (typeof item === 'string' || item.type === 'cm_separator') {
                         item = { type : 'cm_seperator' };
                     }
 


### PR DESCRIPTION
Ability to create a separator item by using additional alias:

##### Use of aliases to create a separator:
- [ ] Make `type` values available:
  - [x] :one: `'cm_seperator'` (original)
  - [x] :two: `'cm_separator'`
  - [ ] :three: `'separator'` (:question:)
- [ ] Update documentation.


##### Example:
```js
items: {
  'sep0': '----', // Any string
  'sep1': { type: 'cm_seperator' }, // 1
  'sep2': { type: 'cm_separator' } // 2
}
```

Closes #411 