### PR TITLE
Add checks for null before using opt.$menu and root.$menu.

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -485,7 +485,7 @@
                         });
                     }
 
-                    root.$menu.trigger('contextmenu:hide');
+                    if (root != null && root.$menu != null) root.$menu.trigger('contextmenu:hide');
                 }, 50);
             },
             // key handled :hover
@@ -974,7 +974,7 @@
                         if (opt.$layer && !opt.hovering && (!(e.pageX >= pos.left && e.pageX <= pos.right) || !(e.pageY >= pos.top && e.pageY <= pos.bottom))) {
                             /* Additional hover check after short time, you might just miss the edge of the menu */
                             setTimeout(function () {
-                                if (!opt.hovering) { opt.$menu.trigger('contextmenu:hide'); }
+                                if (!opt.hovering && opt.$menu != null) { opt.$menu.trigger('contextmenu:hide'); }
                             }, 50);
                         }
                     });


### PR DESCRIPTION
This is a pull-request for issue #352 which I've reported eariler. I used to get quite a lot of Javascript errors of this kind reported on play.freeciv.org by Trackjs (error reporting tool).

I have been using this change in production on play.freeciv.org for about one week, and it has resolved all these javascript errors from being reported any more.