### PR TITLE
Change second 'show' to 'hide' in events docs

### DIFF
--- a/documentation/docs.md
+++ b/documentation/docs.md
@@ -292,7 +292,7 @@ $.contextMenu({
                 return false;
             }            
        },
-       show : function(options){
+       hide : function(options){
            if( confirm('Hide menu with selector ' + options.selector + '?') === true ){
                return true;
            } else {


### PR DESCRIPTION
`show` is used twice, I _assume_ from the context that the second `show` should actually be a `hide`.