### PR TITLE
Issue 413

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ Font-Awesome icons used from [encharm/Font-Awesome-SVG-PNG](https://github.com/e
 
 ## Changelog ##
 
+### 2.2.2-dev ###
+
+#### Fixed
+
+* Callbacks are now called from the scope of the menu the item is in (like a submenu). For now they overwrite root callbacks only if the item is not in a submenu, this so the callbacks are always correct. Unfortunately this will also mean the callbacks option is still not complete if you use the same key for an item in any place. Cant fix that easily. Issue #413.
+
 ### 2.2.1 ###
 
 #### Added

--- a/documentation/docs/runtime-options.md
+++ b/documentation/docs/runtime-options.md
@@ -83,7 +83,9 @@ The element triggering the menu.
 
 ### callbacks
 
-Registered [callbacks](#callback) of all commands (including those of sub-menus).
+Registered [callbacks](#callback) of all commands (including those of sub-menus). 
+
+Warning: If you use the same keys for an item in any place, it will overwrite that callback here.
 
 `callbacks`: `array`  
 
@@ -92,11 +94,15 @@ Registered [callbacks](#callback) of all commands (including those of sub-menus)
 
 Registered commands (including those of sub-menus).
 
+Warning: If you use the same keys for an item in any place, it will overwrite that command here.
+
 `commands`: `array`  
 
 ### inputs
 
 Registered commands of input-type (including those of sub-menus).
+
+Warning: If you use the same keys for an item in any place, it will overwrite that command here.
 
 Access a specific `<input>`: `opt.inputs[key].$input`
 

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -840,9 +840,9 @@
                 e.preventDefault();
                 e.stopImmediatePropagation();
 
-                if ($.isFunction(root.callbacks[key]) && Object.prototype.hasOwnProperty.call(root.callbacks, key)) {
+                if ($.isFunction(opt.callbacks[key]) && Object.prototype.hasOwnProperty.call(opt.callbacks, key)) {
                     // item-specific callback
-                    callback = root.callbacks[key];
+                    callback = opt.callbacks[key];
                 } else if ($.isFunction(root.callback)) {
                     // default callback
                     callback = root.callback;
@@ -1147,7 +1147,9 @@
                         // register commands
                         $.each([opt, root], function (i, k) {
                             k.commands[key] = item;
-                            if ($.isFunction(item.callback)) {
+                            // Overwrite only if undefined or the item is appended to the root. This so it
+                            // doesn't overwrite callbacks of root elements if the name is the same.
+                            if ($.isFunction(item.callback) && (k.callbacks[key] === undefined || opt.type === undefined)) {
                                 k.callbacks[key] = item.callback;
                             }
                         });
@@ -1237,7 +1239,9 @@
                             default:
                                 $.each([opt, root], function (i, k) {
                                     k.commands[key] = item;
-                                    if ($.isFunction(item.callback)) {
+                                    // Overwrite only if undefined or the item is appended to the root. This so it
+                                    // doesn't overwrite callbacks of root elements if the name is the same.
+                                    if ($.isFunction(item.callback) && (k.callbacks[key] === undefined || opt.type === undefined)) {
                                         k.callbacks[key] = item.callback;
                                     }
                                 });

--- a/test/unit/test-events.js
+++ b/test/unit/test-events.js
@@ -175,8 +175,8 @@ function testQUnit(name, itemClickEvent, triggerEvent) {
     $('.context-menu-submenu .context-menu-item').first().trigger(triggerEvent);
     $('.context-menu-submenu .context-menu-item').last().trigger(triggerEvent);
 
-    assert.equal(firstCallback, 1)
-    assert.equal(secondCallback, 1)
+    assert.equal(firstCallback, 1);
+    assert.equal(secondCallback, 1);
   })
 };
 

--- a/test/unit/test-events.js
+++ b/test/unit/test-events.js
@@ -143,8 +143,15 @@ function testQUnit(name, itemClickEvent, triggerEvent) {
   });
 
   QUnit.test('items in seconds submenu to not override callbacks', function (assert) {
-    var firstCallback = false, secondCallback = false;
+    var firstCallback = false, firstSubCallback = false, secondSubCallback = false;
     createContextMenu({
+      firstitem: {
+        name: 'firstitem',
+        icon: 'copy',
+        callback : function(){
+          firstCallback = true;
+        }
+      },
       firstsubmenu: {
         name: 'Copy',
         icon: 'copy',
@@ -153,7 +160,7 @@ function testQUnit(name, itemClickEvent, triggerEvent) {
             name : "firstitem",
             icon : "copy",
             callback : function(){
-              firstCallback = true;
+              firstSubCallback = true;
             }
           }
         }
@@ -166,17 +173,20 @@ function testQUnit(name, itemClickEvent, triggerEvent) {
             name : "firstitem",
             icon : "copy",
             callback : function(){
-              secondCallback = true;
+              secondSubCallback = true;
             }
           }
         }
       }
     });
-    $('.context-menu-submenu .context-menu-item').first().trigger(triggerEvent);
-    $('.context-menu-submenu .context-menu-item').last().trigger(triggerEvent);
+    $('.context-menu-item').first().trigger(triggerEvent);
+    $('.context-menu-submenu .context-menu-item').each(function(i,e){
+      $(e).trigger(triggerEvent)
+    });
 
     assert.equal(firstCallback, 1);
-    assert.equal(secondCallback, 1);
+    assert.equal(firstSubCallback, 1);
+    assert.equal(secondSubCallback, 1);
   })
 };
 

--- a/test/unit/test-events.js
+++ b/test/unit/test-events.js
@@ -141,6 +141,43 @@ function testQUnit(name, itemClickEvent, triggerEvent) {
     assert.equal(menuOpenCounter, 0, 'selected menu wat not opened');
     destroyContextMenuAndCleanup();
   });
+
+  QUnit.test('items in seconds submenu to not override callbacks', function (assert) {
+    var firstCallback = false, secondCallback = false;
+    createContextMenu({
+      firstsubmenu: {
+        name: 'Copy',
+        icon: 'copy',
+        items: {
+          firstitem : {
+            name : "firstitem",
+            icon : "copy",
+            callback : function(){
+              firstCallback = true;
+            }
+          }
+        }
+      },
+      secondsubmenu: {
+        name: 'Copy',
+        icon: 'copy',
+        items: {
+          firstitem : {
+            name : "firstitem",
+            icon : "copy",
+            callback : function(){
+              secondCallback = true;
+            }
+          }
+        }
+      }
+    });
+    $('.context-menu-submenu .context-menu-item').first().trigger(triggerEvent);
+    $('.context-menu-submenu .context-menu-item').last().trigger(triggerEvent);
+
+    assert.equal(firstCallback, 1)
+    assert.equal(secondCallback, 1)
+  })
 };
 
 testQUnit('contextMenu events', '', 'mouseup')


### PR DESCRIPTION
Callbacks should be called from the scope of the menu the item is in (like a submenu). For now overwrite root callbacks only if the item is not in a submenu, this so the callbacks are always correct. Unfortunately this will also mean the callbacks option is still not complete if you use the same key for an item in any place. Cant fix that easily. Fixes #413.