### PR TITLE
Context menu async loading sub-menu's

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1159,14 +1159,12 @@
                             }
                         });
                     } else {
-
                         // add label for input
                         if (item.type === 'cm_seperator') {
                             $t.addClass('context-menu-separator ' + root.classNames.notSelectable);
                         } else if (item.type === 'html') {
                             $t.addClass('context-menu-html ' + root.classNames.notSelectable);
-                        }
-                        else if (item.type === 'sub') {
+                        } else if (item.type === 'sub') {
                            //we don't want to execute the next else-if if it is a sub.
                         } else if (item.type) {
                             $label = $('<label></label>').appendTo($t);
@@ -1258,8 +1256,7 @@
                                 break;
                         }
 
-                        if (item.type === 'sub')
-                        {
+                        if (item.type === 'sub') {
                             //if item contains items, and this is a promise, we should create it later
                             //check if subitems is of type promise. If it is a promise we need to create it later, after promise has been resolved
                             if ('function' === typeof item.items.then) {
@@ -1269,7 +1266,6 @@
                                 // normal submenu.
                                 op.create(item, root);
                             }
-                           
                         }
                         // disable key listener in <input>
                         if (item.type && item.type !== 'sub' && item.type !== 'html' && item.type !== 'cm_seperator') {

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery contextMenu v@VERSION - Plugin for simple contextMenu handling
+ * jQuery contextMenu @VERSION - Plugin for simple contextMenu handling
  *
  * Version: @VERSION
  *
@@ -1061,7 +1061,6 @@
                 if (root === undefined) {
                     root = opt;
                 }
-
                 // create contextMenu
                 opt.$menu = $('<ul class="context-menu-list"></ul>').addClass(opt.className || '').data({
                     'contextMenu': opt,

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1232,11 +1232,18 @@
 
                             case 'sub':
                                 createNameNode(item).appendTo($t);
-
                                 item.appendTo = item.$node;
-                                //op.create(item, root); decide later, might be a promise.
                                 $t.data('contextMenu', item).addClass('context-menu-submenu');
                                 item.callback = null;
+								 //if item contains items, and this is a promise, we should create it later
+								//check if subitems is of type promise. If it is a promise we need to create it later, after promise has been resolved
+								if ('function' === typeof item.items.then) {
+									// probably a promise, process it, when completed it will create the sub menu's.
+									op.processPromises(item, root, item.items);
+								} else {
+									// normal submenu.
+									op.create(item, root);
+								}
                                 break;
 
                             case 'html':
@@ -1256,17 +1263,6 @@
                                 break;
                         }
 
-                        if (item.type === 'sub') {
-                            //if item contains items, and this is a promise, we should create it later
-                            //check if subitems is of type promise. If it is a promise we need to create it later, after promise has been resolved
-                            if ('function' === typeof item.items.then) {
-                                // probably a promise, process it, when completed it will create the sub menu's.
-                                op.processPromises(item, root, item.items);
-                            } else {
-                                // normal submenu.
-                                op.create(item, root);
-                            }
-                        }
                         // disable key listener in <input>
                         if (item.type && item.type !== 'sub' && item.type !== 'html' && item.type !== 'cm_seperator') {
                             $input

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1,7 +1,7 @@
 /*!
- * jQuery contextMenu @VERSION - Plugin for simple contextMenu handling
+ * jQuery contextMenu v@VERSION - Plugin for simple contextMenu handling
  *
- * Version: @VERSION
+ * Version: v@VERSION
  *
  * Authors: Björn Brala (SWIS.nl), Rodney Rehm, Addy Osmani (patches for FF)
  * Web: http://swisnl.github.io/jQuery-contextMenu/

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1159,7 +1159,7 @@
                             }
                         });
                     } else {
-                        var hasSubItems = false;
+
                         // add label for input
                         if (item.type === 'cm_seperator') {
                             $t.addClass('context-menu-separator ' + root.classNames.notSelectable);
@@ -1167,9 +1167,8 @@
                             $t.addClass('context-menu-html ' + root.classNames.notSelectable);
                         }
                         else if (item.type === 'sub') {
-                            hasSubItems = true;//we don't want to execute the next else-if if it is a sub.
-                        }
-                        else if (item.type) {
+                           //we don't want to execute the next else-if if it is a sub.
+                        } else if (item.type) {
                             $label = $('<label></label>').appendTo($t);
                             createNameNode(item).appendTo($label);
 
@@ -1180,7 +1179,6 @@
                                 k.inputs[key] = item;
                             });
                         } else if (item.items) {
-                            hasSubItems = true;
                             item.type = 'sub';
                         }
 
@@ -1260,7 +1258,7 @@
                                 break;
                         }
 
-                        if (hasSubItems)
+                        if (item.type === 'sub')
                         {
                             //if item contains items, and this is a promise, we should create it later
                             //check if subitems is of type promise. If it is a promise we need to create it later, after promise has been resolved
@@ -1462,7 +1460,7 @@
                     op.update(opt, root);//correctly update position if user is already hovered over menu item
                     root.positionSubmenu.call(opt.$node, opt.$menu); //positionSubmenu, will only do anything if user already hovered over menu item that just got new subitems.
                 };
-                //wait for promise completion. success, error, notify. (don't track notify).
+                //wait for promise completion. .then(success, error, notify) (we don't track notify). Bind the opt and root to avoid scope problems
                 promise.then(completedPromise.bind(this, opt, root), errorPromise.bind(this, opt, root));
             }
         };

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1165,7 +1165,11 @@
                             $t.addClass('context-menu-separator ' + root.classNames.notSelectable);
                         } else if (item.type === 'html') {
                             $t.addClass('context-menu-html ' + root.classNames.notSelectable);
-                        } else if (item.type) {
+                        }
+                        else if (item.type === 'sub') {
+                            hasSubItems = true;//we don't want to execute the next else-if if it is a sub.
+                        }
+                        else if (item.type) {
                             $label = $('<label></label>').appendTo($t);
                             createNameNode(item).appendTo($label);
 
@@ -1433,16 +1437,16 @@
                 return $layer;
             },
             processPromises: function (opt, root, promise) {
-                function completedPromise(items) {
+                function completedPromise(opt,root,items) {
                     //completed promise (dev called promise.resolve)
                     //we now have a list of items which can be used to create the rest of the context menu.
                     if (items === undefined) {
                         //meh, null result, dev should have checked
                         errorPromise(undefined);//own error object
                     }
-                    finishPromiseProcess(items);
+                    finishPromiseProcess(opt,root, items);
                 };
-                function errorPromise(errorItem) {
+                function errorPromise(opt,root,errorItem) {
                     //user called promise.reject() with an error item, if not, provide own error item.
                     if ( typeof errorItem === 'string'  || errorItem === undefined) {
                         errorItem = { "error": { name: "No items and no error item", icon: "context-menu-icon context-menu-icon-quit" } };
@@ -1450,16 +1454,16 @@
                             (console.error || console.log).call(console, 'When you reject a promise, provide an "items" object, equal to normal sub-menu items');
                         }
                     }
-                    finishPromiseProcess(errorItem);
+                    finishPromiseProcess(opt,root,errorItem);
                 };
-                function finishPromiseProcess(items) {
+                function finishPromiseProcess(opt,root,items) {
                     opt.items = items;//override promise to items.
                     op.create(opt, root, true);//create submenu
                     op.update(opt, root);//correctly update position if user is already hovered over menu item
                     root.positionSubmenu.call(opt.$node, opt.$menu); //positionSubmenu, will only do anything if user already hovered over menu item that just got new subitems.
                 };
                 //wait for promise completion. success, error, notify. (don't track notify).
-                promise.then(completedPromise, errorPromise);
+                promise.then(completedPromise.bind(this, opt, root), errorPromise.bind(this, opt, root));
             }
         };
 

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1442,12 +1442,14 @@
                 };
                 function errorPromise(opt,root,errorItem) {
                     //user called promise.reject() with an error item, if not, provide own error item.
-                    if ( typeof errorItem === 'string'  || errorItem === undefined) {
+                    if (errorItem === undefined) {
                         errorItem = { "error": { name: "No items and no error item", icon: "context-menu-icon context-menu-icon-quit" } };
                         if (window.console) {
                             (console.error || console.log).call(console, 'When you reject a promise, provide an "items" object, equal to normal sub-menu items');
                         }
-                    }
+                    }else if(typeof errorItem === 'string'){
+						errorItem = { "error": { name: errorItem } };
+					}
                     finishPromiseProcess(opt,root,errorItem);
                 };
                 function finishPromiseProcess(opt,root,items) {


### PR DESCRIPTION
Hi,

Issue: #429
With this feature it is possible to load sub-menu items AFTER the context menu has been opened. By providing a [Jquery promise](http://api.jquery.com/deferred.promise/) for the "items". After the promise will be resolved or rejected the items will be shown in the context menu.

Example usage:

```javascript
    var errorItems = { "errorItem": { name: "Could not load items" },};//example usage if you want to reject promise
    var loadItems = function () {//example method that will eventually do an async call
        var dfd = jQuery.Deferred();
        setTimeout(function () {
            dfd.resolve(subItems);
        }, 1000);
        //setTimeout(function () {
        //    dfd.reject(errorItems);
        //}, 1000); //could be used to reject items, providing the same format list.
        return dfd.promise();//return a jquery promise, see http://api.jquery.com/deferred.promise/
    };

    var subItems = {
        "sub1": { name: "Submenu1", icon: "edit" },
        "sub2": { name: "Submenu2", icon: "cut" },
    };
    //normal context menu initialization.
    $.contextMenu({
        selector: '.context-menu-one',
        build: function ($trigger, e) {
            return {
                callback: function (key, options) {
                    var m = "clicked: " + key;
                    console.log(m);
                },
                items: {
                    "edit": { name: "Edit", icon: "edit" },
                    "cut": { name: "Cut", icon: "cut" },
                    "status": {
                        name: "Status",
                        icon: "delete",
                        items: loadItems(),//providing promise instead of items
                    },
                }
            };
        }
    });
````

working plunker:
https://embed.plnkr.co/iEkk5Ohrja86xf4UKObA/

**Implementation**
Looking at the code changes, which is commented quite extensively anyway: It checks on create for all sub-items if `item.items` is a promise. If so it will use another function `processPromises` within operations to deal with this. There, it will wait for either `promise.resolve` or `promise.reject`. If one of these occur it will override the `items` of the current node (`opt`) which will now contain actual items. Thereafter it will create the sub-menu.
We also call `op.update()` to put the `$node` on a correct x and y position, thereafter we can call `root.positionSubmenu()`, which will correctly position the sub-menu, only when the user already is hovering over the menu item.
Two more adjustments: inside `positionSubmenu` we have to check if $menu is undefined. Because `focusItem` calls this function anyway. This just prevents an console error.
And: When appending css styles when creating the context (sub) menu, add an extra check if it already has a 'sub' type. This because we call create again with an item that already has `sub` and should not execute the last else-if.

TODO:
- console error when closing context menu before promise is resolved
- Unit tests need to be created for this.
- optional nice to have: loading icon when promise is being resolved.