### PR TITLE
Add check for if opt.$menu is null when handling ESC key callback.

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -639,7 +639,7 @@
 
                     case 27: // esc
                         handle.keyStop(e, opt);
-                        opt.$menu.trigger('contextmenu:hide');
+                        if (opt.$menu != null) opt.$menu.trigger('contextmenu:hide');
                         return;
 
                     default: // 0-9, a-z


### PR DESCRIPTION
Add check for if opt.$menu is null when handling ESC key callback.

This bug can be reproduced in the following way:
1. Go to Freeciv-web on https://play.freeciv.org and start a game.
2. Right-clicking on a unit, then the context menu is shown.
3. Press the ESC key.
4. Then a Javascript error occurs in the JavaScript console.
