### PR TITLE
add focus for contenteditable elements on `context-menu-layer` right click

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -453,6 +453,18 @@
                     if (document.elementFromPoint && root.$layer) {
                         root.$layer.hide();
                         target = document.elementFromPoint(x - $win.scrollLeft(), y - $win.scrollTop());
+                        
+                        // also need to try and focus this element if we're in a contenteditable area,
+                        // as the layer will prevent the browser mouse action we want
+                        if (target.isContentEditable) {
+                           var range = document.createRange(),
+                              sel = window.getSelection();
+                           range.selectNode(target);
+                           range.collapse(true);
+                           sel.removeAllRanges();
+                           sel.addRange(range);
+                        }
+                        
                         root.$layer.show();
                     }
 


### PR DESCRIPTION
When we have the context menu open and the `context-menu-layer` is being shown, subsequent right clicks on contenteditable elements won't focus the cursor on them. This PR will check if the target element of a right click is a contenteditable element, and if so, use window.getSelection() to focus it.