### PR TITLE
Two bugfixes

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -353,9 +353,12 @@
             },
             // contextMenu left-click trigger
             click: function (e) {
+                var $this = $(this);
+                if ($this.hasClass('context-menu-disabled') || $(e.delegateTarget).hasClass('context-menu-disabled'))
+                    return
                 e.preventDefault();
                 e.stopImmediatePropagation();
-                $(this).trigger($.Event('contextmenu', {data: e.data, pageX: e.pageX, pageY: e.pageY}));
+                $this.trigger($.Event('contextmenu', {data: e.data, pageX: e.pageX, pageY: e.pageY}));
             },
             // contextMenu right-click trigger
             mousedown: function (e) {

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1709,7 +1709,8 @@
                         }
 
                         // Is this menu equest to the context called from
-                        if (!$(context).is(o.selector)) {
+                        var $context = $(context);
+                        if (!($context.is(o.selector) || $context.has(o.selector))) {
                             return true;
                         }
 


### PR DESCRIPTION
Hi.
Thank you for your nice plug-in!

I use your plug-in as delegated pattern with left click option, and found that  a function to disable
menu (by passing false as an argument) and a function to destroy menu (by passing'destroy' as an argument) do not work in the case of delegated pattern.

Here is a PR to fix them though I am not sure that it is a right way.

About the first issue, I fixed it in the case of left click option, but have no idea in defaul case (right click).

