### PR TITLE
Check for opt.$menu != null instead of opt.$menu !== null.

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -507,7 +507,7 @@
                         });
                     }
 
-                    if (root !== null && root.$menu !== null) {
+                    if (root !== null && root.$menu != null) {
                         root.$menu.trigger('contextmenu:hide');
                     }
                 }, 50);
@@ -671,7 +671,7 @@
 
                     case 27: // esc
                         handle.keyStop(e, opt);
-                        if (opt.$menu !== null) {
+                        if (opt.$menu != null) {
                             opt.$menu.trigger('contextmenu:hide');
                         }
                         return;


### PR DESCRIPTION
 This prevents calling trigger() on an undefined object. Based on my testing opt.$menu != null should be used to check for undefined, since this fixes the actual error based on my testing.

This is related to my previous pull request here:
https://github.com/swisnl/jQuery-contextMenu/pull/462