### PR TITLE
events not triggering

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -448,7 +448,6 @@
                     offset;
 
                 e.preventDefault();
-                // e.stopImmediatePropagation();
 
                 setTimeout(function () {
                     var $window;


### PR DESCRIPTION
Fixes #454 - events not triggering when opening a contextMenu right after the other