### PR TITLE
Touch start added for iPad and iPhone

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1689,6 +1689,9 @@
                     case 'left':
                         $context.on('click' + o.ns, o.selector, o, handle.click);
                         break;
+				    case 'touchstart':
+                        $context.on('touchstart' + o.ns, o.selector, o, handle.click);
+                        break;
                     /*
                      default:
                      // http://www.quirksmode.org/dom/events/contextmenu.html


### PR DESCRIPTION
Hi,
I used your plugin in iPad 'left' click trigger, but since click action in iPad is triggered only after few milliseconds, there is a 300ms delay in opening the context menu.

So I added the 'touchstart' trigger option.

I tried gulp compile the code, but I can't. So I am committing only the source code.

Thank You.
