### PR TITLE
Add option to hide the menu on a second click/trigger of the trigger element

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -116,6 +116,10 @@
             // flag denoting if a second trigger should simply move (true) or rebuild (false) an open menu
             // as long as the trigger happened on one of the trigger-element's child nodes
             reposition: true,
+            // Flag denoting if a second trigger should close the menu, as long as 
+            // the trigger happened on one of the trigger-element's child nodes.
+            // This overrides the reposition option.
+            hideOnSecondTrigger: false,
 
             //ability to select submenu
             selectableSubMenu: false,
@@ -471,7 +475,12 @@
                         $(target).trigger(e);
                         root.$layer.show();
                     }
-
+                    
+                    if (root.hideOnSecondTrigger && triggerAction && root.$menu !== null && typeof root.$menu !== 'undefined') {
+                      root.$menu.trigger('contextmenu:hide');
+                      return;
+                    }
+                    
                     if (root.reposition && triggerAction) {
                         if (document.elementFromPoint) {
                             if (root.$trigger.is(target)) {


### PR DESCRIPTION
As the title says...
I was surprised to discover that the default behaviour when clicking on the trigger element a second time is to reposition the menu. However I had set-up the trigger to respond to left clicks, so given that right clicks are the default trigger action reposition makes more sense. 

It still seemed like a good idea to have the option of hiding the menu on a second trigger though; I think this would be the expected behaviour in the case of left-clicks or touch-screen taps (hence my initial surprise ;)). Perhaps this could even be the default behaviour for left-click or touch-screen taps? For now this PR is only adding the option and setting it to false by default.