### PR TITLE
updated documentation for `callback`

### DIFF
--- a/documentation/docs/items.md
+++ b/documentation/docs/items.md
@@ -93,7 +93,7 @@ The Callback is executed in the context of the triggering object. The first argu
 
 If no callback and no default callback is specified, the item will not have an action
 
-`callback`: `function(itemKey, opt, rootMenu, originalEvent)`
+`callback`: `function(itemKey, opt, originalEvent)`
 
 #### Example
 


### PR DESCRIPTION
the documentation suggests there are 4 parameters passed to the function, but there are only 3 parameters. Removed the `rootMenu` parameter mentioned...