### PR TITLE
docs: Fix simple typo, renderd -> rendered

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ usable as commands are being ignored altogether. It also doesn't (optically) dis
 * [command specs](http://www.whatwg.org/specs/web-apps/current-work/multipage/commands.html)
 * [Browser support according to caniuse.com](http://caniuse.com/#search=context%20menu)
 
-Note: While the specs note &lt;option&gt;s to be renderd as regular commands, $.contextMenu will render an actual &lt;select&gt;. import contextMenu from HTML5 &lt;menu&gt;:
+Note: While the specs note &lt;option&gt;s to be rendered as regular commands, $.contextMenu will render an actual &lt;select&gt;. import contextMenu from HTML5 &lt;menu&gt;:
 
 ```javascript
 $.contextMenu("html5");

--- a/documentation/docs/html5-polyfill.md
+++ b/documentation/docs/html5-polyfill.md
@@ -47,7 +47,7 @@ considering the following HTML `$.contextMenu.fromMenu($('#html5menu'))` will re
 
 The `<menu>` must be hidden but not removed, as all command events (clicks) are passed-thru to the original command element!
 
-Note: While the specs note `<option>`s to be renderd as regular commands, `$.contextMenu` will render an actual `<select>`.
+Note: While the specs note `<option>`s to be rendered as regular commands, `$.contextMenu` will render an actual `<select>`.
 
 ## HTML5 `<menu>` shiv/polyfill
 


### PR DESCRIPTION
There is a small typo in README.md, documentation/docs/html5-polyfill.md.

Should read `rendered` rather than `renderd`.

