### PR TITLE
Use Rails asset pipeline URL functions to load icon font if they exist

### DIFF
--- a/src/sass/icons/_mixins.scss
+++ b/src/sass/icons/_mixins.scss
@@ -2,13 +2,23 @@
 
 $context-menu-icons: () !default;
 
+@function context-menu-font-url($url) {
+  @if function-exists(asset-url) {
+    @return asset-url($url);
+  } @else if function-exists(font-url) {
+    @return font-url($url);
+  } @else {
+    @return url($url);
+  }
+}
+
 @font-face {
   font-family: '#{$context-menu-icon-font-name}';
-  src: url('#{$context-menu-icon-font-path}#{$context-menu-icon-font-name}.eot?#{$context-menu-icons-cachebust}');
-  src: url('#{$context-menu-icon-font-path}#{$context-menu-icon-font-name}.eot?#{$context-menu-icons-cachebust}#iefix') format('embedded-opentype'),
-  url('#{$context-menu-icon-font-path}#{$context-menu-icon-font-name}.woff2?#{$context-menu-icons-cachebust}') format('woff2'),
-  url('#{$context-menu-icon-font-path}#{$context-menu-icon-font-name}.woff?#{$context-menu-icons-cachebust}') format('woff'),
-  url('#{$context-menu-icon-font-path}#{$context-menu-icon-font-name}.ttf?#{$context-menu-icons-cachebust}') format('truetype');
+  src: context-menu-font-url('#{$context-menu-icon-font-path}#{$context-menu-icon-font-name}.eot?#{$context-menu-icons-cachebust}');
+  src: context-menu-font-url('#{$context-menu-icon-font-path}#{$context-menu-icon-font-name}.eot?#{$context-menu-icons-cachebust}#iefix') format('embedded-opentype'),
+  context-menu-font-url('#{$context-menu-icon-font-path}#{$context-menu-icon-font-name}.woff2?#{$context-menu-icons-cachebust}') format('woff2'),
+  context-menu-font-url('#{$context-menu-icon-font-path}#{$context-menu-icon-font-name}.woff?#{$context-menu-icons-cachebust}') format('woff'),
+  context-menu-font-url('#{$context-menu-icon-font-path}#{$context-menu-icon-font-name}.ttf?#{$context-menu-icons-cachebust}') format('truetype');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
I'm working on fixing some 404 errors in a Rails app for work that uses jQuery-contextMenu. We're using the asset pipeline for fonts, which appends digest strings to their filenames. This causes the stylesheet for this library to look for its fonts in the wrong place. 

This PR uses the asset pipeline's Sass helper functions if they exist to ensure that the correct font URLs end up in the compiled CSS in Rails apps. If those functions don't exists, e.g. when using Gulp to build CSS, it'll use `url()`.

A similar approached is used by Slick Carousel to make their stylesheets' font URLs Rails friendly: https://github.com/kenwheeler/slick/blob/master/slick/slick-theme.scss#L33-L40