### PR TITLE
Fix menu jumping to top of screen and disappearing to the right

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1579,8 +1579,13 @@
                 var $menu = opt.$menu;
                 var $menuOffset = $menu.offset();
                 var winHeight = $(window).height();
+                var winWidth = $(window).width();
                 var winScrollTop = $(window).scrollTop();
+                var winScrollLeft = $(window).scrollLeft();
                 var menuHeight = $menu.height();
+                var outerHeight = $menu.outerHeight();
+                var outerWidth = $menu.outerWidth();
+
                 if(menuHeight > winHeight){
                     $menu.css({
                         'height' : winHeight + 'px',
@@ -1588,9 +1593,18 @@
                         'overflow-y': 'auto',
                         'top': winScrollTop + 'px'
                     });
-                } else if(($menuOffset.top < winScrollTop) || ($menuOffset.top + menuHeight > winScrollTop + winHeight)){
+                } else if($menuOffset.top < winScrollTop){
                     $menu.css({
-                        'top': winScrollTop + 'px'
+                      'top': winScrollTop + 'px'
+                    });
+                } else if($menuOffset.top + outerHeight > winScrollTop + winHeight){
+                    $menu.css({
+                      'top': $menuOffset.top - (($menuOffset.top + outerHeight) - (winScrollTop + winHeight)) + "px"
+                    });
+                }
+                if($menuOffset.left + outerWidth > winScrollLeft + winWidth){
+                    $menu.css({
+                      'left': $menuOffset.left - (($menuOffset.left + outerWidth) - (winScrollLeft + winWidth)) + "px"
                     });
                 }
             }


### PR DESCRIPTION
This adds in changes proposed by @lukefoley in issue #749, but uses `$menu.outerHeight()` instead of `$menu.height()` so that part of the menu doesn't leave the window, and fixes the context menu going out of the window when created near the right border of the window.