### PR TITLE
html5 & callback is not actually working #564

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1998,8 +1998,12 @@
                         name: $node.text(),
                         disabled: !!$node.attr('disabled'),
                         callback: (function () {
-                            return function () {
-                                $node.get(0).click();
+                            return function (itemKey, opt, ev) {
+                                if ($node.get(0).onclick !== null) {
+                                    $node.get(0).click();
+                                } else {
+                                    opt.callback(itemKey, opt, ev);
+                                }
                             };
                         })()
                     };
@@ -2017,8 +2021,12 @@
                                 disabled: !!$node.attr('disabled'),
                                 icon: $node.attr('icon'),
                                 callback: (function () {
-                                    return function () {
-                                        $node.get(0).click();
+                                    return function (itemKey, opt, ev) {
+                                        if ($node.get(0).onclick !== null) {
+                                            $node.get(0).click();
+                                        } else {
+                                            opt.callback(itemKey, opt, ev);
+                                        }
                                     };
                                 })()
                             };


### PR DESCRIPTION
To preserve legacy compatibility when building the menu from a HTML5 menu element I propose that you check for the existence of the `onclick` property on the `button`, `menuitem` or `command` tag and if one does not exist then call the root callback function as a fallback:

```
    callback: (function () {
        return function () {
            $node.get(0).click();
        };
    })()
```
Therefore becomes:
```
    callback: (function () {
        return function (itemKey, opt, ev) {
            if ($node.get(0).onclick !== null) {
                $node.get(0).click();
            } else {
                opt.callback(itemKey, opt, ev);
            }
        };
    })()
```
I have no need for legacy compatibility in my app but this works well for me especially when building large menus using the suckerfish methodology.