### PR TITLE
fix: prefix docs site links with GitHub Pages base path

### DIFF
--- a/documentation/_data/eleventyComputed.js
+++ b/documentation/_data/eleventyComputed.js
@@ -7,15 +7,31 @@
 // own URL instead.
 const DEFAULT_SITE_BASE_URL = 'https://swisnl.github.io/jQuery-contextMenu';
 
+function resolvedSiteBaseUrl() {
+  return process.env.SITE_BASE_URL !== undefined ? process.env.SITE_BASE_URL : DEFAULT_SITE_BASE_URL;
+}
+
+// GitHub Pages serves this project off /jQuery-contextMenu/, not the domain
+// root (there's no CNAME) -- so site-relative links need that path segment,
+// not just a leading slash. Derived from the same base URL as assetBase
+// rather than hardcoded, so it stays correct if the site ever moves.
+function sitePathPrefix() {
+  const base = resolvedSiteBaseUrl();
+  if (!base) return '';
+  try {
+    return new URL(base).pathname.replace(/\/$/, '');
+  } catch {
+    return base.replace(/\/$/, '');
+  }
+}
+
 module.exports = {
   // ELEVENTY_FIXTURES=1 (set by the `test:fixtures` npm script) switches
   // demo pages from "public site" mode (SITE_BASE_URL asset URLs) to
   // "local fixture" mode (relative src/dist paths in the checkout, so
   // Playwright exercises the actual code under test).
   isFixtureBuild: () => process.env.ELEVENTY_FIXTURES === '1',
-  assetBase: (data) => (data.isFixtureBuild
-    ? ''
-    : (process.env.SITE_BASE_URL !== undefined ? process.env.SITE_BASE_URL : DEFAULT_SITE_BASE_URL)),
+  assetBase: (data) => (data.isFixtureBuild ? '' : resolvedSiteBaseUrl()),
 
   // Demo page assets: site.css/showcase.js are passthrough-copied one level
   // up from the fixture output root (test/integration/html/jquery-<version>/),
@@ -25,7 +41,7 @@ module.exports = {
   // land at jquery-<version>/<slug>.html, hence the fixed 4-level ../../../..)
   // and deliberately loads the raw src/ files rather than the built dist/
   // bundle, so Playwright exercises the actual source under test.
-  siteAssetBase: (data) => (data.isFixtureBuild ? '..' : ''),
+  siteAssetBase: (data) => (data.isFixtureBuild ? '..' : sitePathPrefix()),
   contextMenuCssHref: (data) => (data.isFixtureBuild
     ? '../../../../dist/jquery.contextMenu.css'
     : `${data.assetBase}/dist/jquery.contextMenu.css`),

--- a/documentation/_includes/base.njk
+++ b/documentation/_includes/base.njk
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{{ title or "jQuery contextMenu" }}</title>
-<link rel="stylesheet" href="/css/site.css">
+<link rel="stylesheet" href="{{ siteAssetBase }}/css/site.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github.min.css" media="(prefers-color-scheme: light)">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/github-dark.min.css" media="(prefers-color-scheme: dark)">
 </head>

--- a/documentation/_includes/nav.njk
+++ b/documentation/_includes/nav.njk
@@ -1,13 +1,13 @@
 <nav class="sidebar">
-  <a href="/"><strong>jQuery contextMenu</strong></a>
+  <a href="{{ siteAssetBase }}/"><strong>jQuery contextMenu</strong></a>
   <ul>
   {% for item in nav %}
     <li>
-      <a class="{{ 'current' if item.id == currentMenu }}" href="{{ item.url }}">{{ item.text }}</a>
+      <a class="{{ 'current' if item.id == currentMenu }}" href="{{ siteAssetBase if item.url[0] == '/' else '' }}{{ item.url }}">{{ item.text }}</a>
       {% if item.items %}
       <ul>
         {% for sub in item.items %}
-        <li><a class="{{ 'current' if sub.id == currentMenu }}" href="{{ sub.url }}">{{ sub.text }}</a></li>
+        <li><a class="{{ 'current' if sub.id == currentMenu }}" href="{{ siteAssetBase if sub.url[0] == '/' else '' }}{{ sub.url }}">{{ sub.text }}</a></li>
         {% endfor %}
       </ul>
       {% endif %}


### PR DESCRIPTION
## Summary
- The docs site at https://swisnl.github.io/jQuery-contextMenu/ is a GitHub Pages *project* site (no custom domain), served under the `/jQuery-contextMenu/` path — but `base.njk` and `nav.njk` hardcoded root-absolute links (`/css/site.css`, `/docs.html`, etc.), which resolve against the domain root instead and 404. This broke all site styling and internal navigation.
- `siteAssetBase` already existed in `eleventyComputed.js` for exactly this purpose but was hardcoded to `''` for public-site builds, and only `demo.njk` actually used it. Now it's derived from `SITE_BASE_URL`/`DEFAULT_SITE_BASE_URL` and used by `base.njk`/`nav.njk` too.

## Test plan
- [x] `npm run docs:build` then verified `documentation/_site/{index,docs}.html` link to `/jQuery-contextMenu/css/site.css` and `/jQuery-contextMenu/...` nav paths
- [x] `SITE_BASE_URL= eleventy ...` (docs:preview mode) still produces plain root-relative links (`/css/site.css`, `/`)
- [x] `ELEVENTY_FIXTURES=1` build (used by acceptance tests) unaffected — still emits `../css/site.css` etc.
- [x] `npm run test-unit` — 22/22 pass
- [x] `npm run test-accept` — 10/10 pass