### PR TITLE
fix: guard against undefined e.data in contextmenu handler

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -311,6 +311,13 @@
             contextmenu: function (e) {
                 var $this = $(this);
 
+                // Guard against handlers firing with missing/incomplete event data
+                // (e.g. a stale/manual invocation not carrying the registered menu
+                // options). Without this, e.data.events.preShow throws.
+                if (!e.data || !e.data.events) {
+                    return;
+                }
+
                 //Show browser context-menu when preShow returns false
                 if (e.data.events.preShow($this,e) === false) {
                     return;
@@ -1751,12 +1758,23 @@
             }
         } else {
             $.each(menus, function () {
-                if (this.selector === $t.selector) {
+                // Note: jQuery.fn.selector was deprecated in jQuery 1.9 and removed in
+                // jQuery 3.0, so $t.selector is always undefined on modern jQuery. This
+                // means a matching menu can only be found when jQuery still exposes the
+                // (legacy) `.selector` property.
+                if (typeof $t.selector !== 'undefined' && this.selector === $t.selector) {
                     $o.data = this;
 
                     $.extend($o.data, {trigger: 'demand'});
                 }
             });
+
+            // Without a matching registered menu there's nothing to show. Bail out
+            // instead of invoking the handler with incomplete/missing event data,
+            // which would throw when it tries to read e.data.events.
+            if (!$o || !$o.data) {
+                return this;
+            }
 
             handle.contextmenu.call($o.target, $o);
         }

--- a/test/unit/contextmenu.test.js
+++ b/test/unit/contextmenu.test.js
@@ -162,6 +162,55 @@ function testQUnit(name, itemClickEvent, triggerEvent) {
 
   });
 
+  QUnit.test('manually triggering contextMenu via a selector matching zero elements does not throw', function(assert) {
+    // Regression test for https://github.com/swisnl/jQuery-contextMenu/issues/777
+    // "TypeError: Cannot read properties of undefined (reading 'events')"
+    //
+    // $.fn.contextMenu() has a "zero-length" code path (this.length === 0)
+    // meant to look up a registered menu by matching jQuery's legacy
+    // `.selector` property. That property was deprecated in jQuery 1.9 and
+    // removed in jQuery 3.0, so on modern jQuery the lookup can never
+    // succeed, yet the handler used to be invoked unconditionally with
+    // whatever (missing) data resulted from the failed lookup.
+    createContextMenu();
+
+    // sanity check: the selector below must not match anything, mirroring
+    // a trigger element that hasn't been inserted yet (or was removed).
+    assert.equal($('.context-menu-does-not-exist').length, 0, 'sanity check: selector matches nothing');
+
+    var didThrow = false;
+    try {
+      $('.context-menu-does-not-exist').contextMenu({x: 0, y: 0});
+    } catch (e) {
+      didThrow = true;
+    }
+
+    assert.notOk(didThrow, 'calling .contextMenu() on a non-matching selector did not throw');
+    assert.equal(menuOpenCounter, 0, 'no contextMenu was opened for a non-matching selector');
+  });
+
+  QUnit.test('manually triggering contextMenu on a detached trigger element does not throw', function(assert) {
+    // Regression test for https://github.com/swisnl/jQuery-contextMenu/issues/777
+    createContextMenu();
+
+    var $trigger = $('.context-menu');
+    $trigger.detach();
+
+    assert.equal($('.context-menu').length, 0, 'sanity check: trigger element no longer in the DOM');
+
+    var didThrow = false;
+    try {
+      $('.context-menu').contextMenu({x: 0, y: 0, target: $trigger[0]});
+    } catch (e) {
+      didThrow = true;
+    }
+
+    assert.notOk(didThrow, 'calling .contextMenu() on a detached trigger did not throw');
+
+    // put it back so afterEach cleanup can find/destroy it normally
+    $('#qunit-fixture').append($trigger);
+  });
+
   QUnit.test('do not open context menu with no visible items', function(assert) {
     createContextMenu({
       copy: {name: 'Copy', icon: 'copy', visible: function(){return false;}},


### PR DESCRIPTION
Calling `.contextMenu()` on a selector that currently matches nothing fell through to a dead code path (comparing jQuery's removed `.selector` property) and still called the handler without any menu data, throwing `Cannot read properties of undefined (reading 'events')`. This bails out instead, and adds a defensive check as a second line of defense.

Fixes #777