### PR TITLE
docs: add dynamic per-row title example to menu-title demo

### DIFF
--- a/documentation/demo/menu-title.md
+++ b/documentation/demo/menu-title.md
@@ -20,6 +20,14 @@ currentMenu: menu-title
 <span class="context-menu-two btn btn-neutral">right click me</span>
 <span class="context-menu-three btn btn-neutral">right click me</span>
 
+<table class="table" style="width:auto;">
+    <tbody>
+        <tr class="context-menu-four" data-username="Alice"><td>right click this row</td></tr>
+        <tr class="context-menu-four" data-username="Bob"><td>right click this row</td></tr>
+        <tr class="context-menu-four" data-username="Carol"><td>right click this row</td></tr>
+    </tbody>
+</table>
+
 
 
 ## Example CSS
@@ -126,6 +134,38 @@ $(function(){
     
     // set a title
     $('.data-title').attr('data-menutitle', "Some JS Title");
+
+    // register menu with a title that is computed dynamically, right before
+    // the menu is shown, from data on the element that was right-clicked.
+    // This re-uses the same "data-title" CSS rule from above, but instead of
+    // setting data-menutitle once up front, it is set inside the "show" event,
+    // which fires with `this` bound to the trigger element (the row that was
+    // right-clicked) and receives the menu's `opt` object -- opt.$menu is the
+    // menu itself, so it can be updated before it becomes visible.
+    $.contextMenu({
+        selector: '.context-menu-four',
+        className: 'data-title',
+        callback: function(key, options) {
+            var m = "clicked: " + key;
+            window.console && console.log(m) || alert(m);
+        },
+        events: {
+            show: function(opt) {
+                // `this` is the row (trigger element) that was right-clicked
+                var username = $(this).data('username');
+                opt.$menu.attr('data-menutitle', 'User: ' + username);
+            }
+        },
+        items: {
+            "edit": {name: "Edit", icon: "edit"},
+            "cut": {name: "Cut", icon: "cut"},
+            "copy": {name: "Copy", icon: "copy"},
+            "paste": {name: "Paste", icon: "paste"},
+            "delete": {name: "Delete", icon: "delete"},
+            "sep1": "---------",
+            "quit": {name: "Quit", icon: function($element, key, item){ return 'context-menu-icon context-menu-icon-quit'; }}
+        }
+    });
 });
 </script>
 
@@ -137,7 +177,21 @@ $(function(){
 <span class="context-menu-two btn btn-neutral">right click me</span>
 
 <span class="context-menu-three btn btn-neutral">right click me</span>
+
+<table class="table" style="width:auto;">
+    <tbody>
+        <tr class="context-menu-four" data-username="Alice"><td>right click this row</td></tr>
+        <tr class="context-menu-four" data-username="Bob"><td>right click this row</td></tr>
+        <tr class="context-menu-four" data-username="Carol"><td>right click this row</td></tr>
+    </tbody>
+</table>
 ```
+
+> Note: the third menu above sets `data-menutitle` once, right after
+> `$.contextMenu()` is called, so every row shows the same static title. The
+> fourth menu (the table) sets `data-menutitle` from inside the `show` event
+> instead, so the title is recomputed from the row that was actually
+> right-clicked every time the menu opens.
 
 
 


### PR DESCRIPTION
The existing example only sets the title once at page load. Adds one that sets it inside the `show` event instead, so it can vary based on what was right-clicked, matching the answer already given on #769.