### PR TITLE
fix: show/hide animation didn't play on menu open

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1607,6 +1607,12 @@
                 // position:absolute within position:absolute; min-width:100; max-width:200; results in width: 100;
                 // kinda sucks hard...
 
+                // remember the display value set before measuring (e.g. "none" while the
+                // root menu is hidden), so it can be restored afterwards instead of being
+                // cleared. Clearing it would make the menu visible again before the show
+                // animation runs, defeating fadeIn/slideDown (see issue #764).
+                var originalDisplay = $menu[0].style.display;
+
                 // determine width of absolutely positioned element
                 $menu.css({position: 'absolute', display: 'block'});
                 // don't apply yet, because that would break nested elements' widths
@@ -1635,6 +1641,9 @@
                     }).outerWidth(function () {
                         return $(this).data('width');
                     });
+                    // restore the display value that was in place before measuring
+                    // (e.g. "none" for a menu that's about to be shown with an animation)
+                    $menu.css('display', originalDisplay);
                 }
             },
             // Move the direct sub-menus of a (scrollable) root menu out to <body>,


### PR DESCRIPTION
## Summary
Fixes #764. `op.resize()` measures the menu's width by temporarily forcing `display: block`, then resets the inline `display` style back to `''` at the end — but it did this *before* the show animation ran, so a hidden menu (`display: none`) was already fully visible before `slideDown`/`fadeIn` ever started, making the animation a no-op.

Fix: capture the menu's inline `display` value before the measurement pass and restore that exact value afterward, instead of blanking it to `''`.

## Test plan
- [x] `npm run test-unit` — 27/27 pass
- [x] `npx playwright test` — 10/10 pass
- [x] Verified via a Playwright script that hooks `$.fn.slideDown` that the menu now genuinely starts hidden (`display: none`, height 0) and animates in, instead of already being fully shown at animation start