### PR TITLE
fix: legacy fa-* icon shorthand bled Font Awesome styling into the menu item

### DIFF
--- a/documentation/demo/fontawesome-icons.md
+++ b/documentation/demo/fontawesome-icons.md
@@ -15,6 +15,8 @@ currentMenu: fontawesome-icons
 
 The menu allows you to use [FontAwesome](http://fontawesome.io/) [icons](http://fontawesome.io/icons/) in your menu. Just include the CSS for FontAwesome and you are ready to go.
 
+With Font Awesome 5/6, always prefix the icon name with its style class (`fas `, `far `, `fab `, `fad ` or `fal `), e.g. `icon: "fas fa-edit"`. Using just the icon name (e.g. `icon: "fa-edit"`) is only kept for backwards compatibility with Font Awesome 4 and may not render correctly with newer Font Awesome versions/kits.
+
 <span class="context-menu-one btn btn-neutral">right click me</span>
 
 ## Example code
@@ -28,10 +30,10 @@ The menu allows you to use [FontAwesome](http://fontawesome.io/) [icons](http://
             window.console && console.log(m) || alert(m);
         },
         items: {
-            "edit": {name: "Edit", icon: "fa-edit"},
-            "cut": {name: "Beer", icon: "fa-beer"},
-            copy: {name: "Cloud download", icon: "fa-cloud-download"},
-            "paste": {name: "Certificate", icon: "fa-certificate"}
+            "edit": {name: "Edit", icon: "fas fa-edit"},
+            "cut": {name: "Beer", icon: "fas fa-beer"},
+            copy: {name: "Cloud download", icon: "fas fa-cloud-download-alt"},
+            "paste": {name: "Certificate", icon: "fas fa-certificate"}
         }
     });
 

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1453,7 +1453,15 @@
                                     $t.addClass(root.classNames.icon + ' ' + root.classNames.icon + '--fa5');
                                     item._icon = $('<i class="' + item.icon + '"></i>');
                                 } else if (typeof(item.icon) === 'string' && item.icon.substring(0, 3) === 'fa-') {
-                                    item._icon = root.classNames.icon + ' ' + root.classNames.icon + '--fa fa ' + item.icon;
+                                    // legacy Font Awesome 4 style icon class (e.g. "fa-trash"), kept for
+                                    // backwards compatibility. Just like the fas/far/fab/fad/fal syntax
+                                    // above, this needs its own <i> tag instead of being applied to the
+                                    // menu item itself: Font Awesome's classes set font-family/font-weight
+                                    // and their own ::before content on whatever element they're put on,
+                                    // which used to bleed into (and bold) the item's label text and clash
+                                    // with this plugin's own icon styling.
+                                    $t.addClass(root.classNames.icon + ' ' + root.classNames.icon + '--fa5');
+                                    item._icon = $('<i class="fa ' + item.icon + '"></i>');
                                 } else {
                                     item._icon = root.classNames.icon + ' ' + root.classNames.icon + '-' + item.icon;
                                 }

--- a/test/unit/contextmenu.test.js
+++ b/test/unit/contextmenu.test.js
@@ -291,6 +291,19 @@ function testQUnit(name, itemClickEvent, triggerEvent) {
 
         assert.equal($('i.fas.fa-beer').length, 1, 'FontAwesome <i> tag was not created');
     });
+
+    QUnit.test('legacy fa-* icon shorthand creates its own icon element instead of tainting the item', function(assert) {
+        createContextMenu({
+            copy: {name: 'Copy', icon: 'fa-trash'}
+        });
+
+        $(".context-menu").contextMenu();
+
+        var $item = $('.context-menu-item').first();
+
+        assert.equal($item.find('i.fa.fa-trash').length, 1, 'FontAwesome <i> tag was not created for legacy "fa-*" icon shorthand');
+        assert.notOk($item.hasClass('fa') || $item.hasClass('fa-trash'), 'FontAwesome classes should not be applied to the menu item itself, as that bleeds the icon font (and its font-weight) into the item label text');
+    });
 }
 
 testQUnit('contextMenu events', '', 'mouseup');


### PR DESCRIPTION
## Summary
Fixes #761. Menu items configured with the old-style Font Awesome shorthand (e.g. `icon: "fa-trash"`) had the raw `fa`/`fa-trash` classes applied directly to the `<li>` item instead of a dedicated `<i>` element, unlike the newer `"fas fa-trash"` syntax which already isolates its classes. Font Awesome's classes set `font-family`/`font-weight` and their own `::before` content on whatever element they're applied to, so putting them on the item itself bled the icon font into the item's label text and clashed with this plugin's own `::before`-based icon styling — producing bold/garbled labels instead of an icon.

Fix: wrap the legacy shorthand classes in their own `<i>` element, same as the `fas/far/fab/fad/fal` branch already does, reusing the existing `--fa5` styling. Also corrected the FontAwesome demo, which was using the broken legacy shorthand and actively steering users into this bug.

## Test plan
- [x] Added a regression test asserting the legacy shorthand creates its own icon element and doesn't apply FA classes to the `<li>`
- [x] `npm run test-unit` — 29/29 pass