### PR TITLE
fix: left-click trigger leaked a synthetic contextmenu event to unrelated ancestor listeners

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -459,6 +459,16 @@
                 hoveract.timer = setTimeout(function () {
                     hoveract.timer = null;
                     $document.off('mousemove.contextMenuShow');
+
+                    // The trigger may have been removed from the document while
+                    // this delay was pending. Triggering a bubbling event used to
+                    // make that a silent no-op (a detached node can't bubble to
+                    // the delegated listener); calling the dispatcher directly
+                    // doesn't have that safety net, so check explicitly.
+                    if (!$.contains(document.documentElement, $this[0])) {
+                        return;
+                    }
+
                     $currentTrigger = $this;
                     // See handle.click for why we call the dispatcher directly
                     // instead of triggering a bubbling 'contextmenu' event.

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -386,7 +386,19 @@
             click: function (e) {
                 e.preventDefault();
                 e.stopImmediatePropagation();
-                $(this).trigger($.Event('contextmenu', {data: e.data, pageX: e.pageX, pageY: e.pageY}));
+                // Invoke the dispatcher directly instead of triggering a real,
+                // bubbling 'contextmenu' event: a bubbling synthetic event is
+                // indistinguishable from a genuine right-click to any other
+                // 'contextmenu' listener bound on an ancestor element, causing
+                // unrelated handlers elsewhere on the page to fire on a plain
+                // left-click. See https://github.com/swisnl/jQuery-contextMenu/issues/754
+                handle.contextmenu.call(this, $.Event('contextmenu', {
+                    data: e.data,
+                    pageX: e.pageX,
+                    pageY: e.pageY,
+                    target: this,
+                    currentTarget: this
+                }));
             },
             // contextMenu right-click trigger
             mousedown: function (e) {
@@ -411,7 +423,15 @@
                     e.preventDefault();
                     e.stopImmediatePropagation();
                     $currentTrigger = $this;
-                    $this.trigger($.Event('contextmenu', {data: e.data, pageX: e.pageX, pageY: e.pageY}));
+                    // See handle.click for why we call the dispatcher directly
+                    // instead of triggering a bubbling 'contextmenu' event.
+                    handle.contextmenu.call(this, $.Event('contextmenu', {
+                        data: e.data,
+                        pageX: e.pageX,
+                        pageY: e.pageY,
+                        target: this,
+                        currentTarget: this
+                    }));
                 }
 
                 $this.removeData('contextMenuActive');
@@ -440,10 +460,14 @@
                     hoveract.timer = null;
                     $document.off('mousemove.contextMenuShow');
                     $currentTrigger = $this;
-                    $this.trigger($.Event('contextmenu', {
+                    // See handle.click for why we call the dispatcher directly
+                    // instead of triggering a bubbling 'contextmenu' event.
+                    handle.contextmenu.call($this[0], $.Event('contextmenu', {
                         data: hoveract.data,
                         pageX: hoveract.pageX,
-                        pageY: hoveract.pageY
+                        pageY: hoveract.pageY,
+                        target: $this[0],
+                        currentTarget: $this[0]
                     }));
                 }, e.data.delay);
             },

--- a/test/unit/issue-754-repro.test.js
+++ b/test/unit/issue-754-repro.test.js
@@ -39,3 +39,37 @@ QUnit.test('left-click trigger should not bubble a synthetic contextmenu event t
   assert.equal(menuOpenCount, 1, 'sanity check: our own contextMenu opened once');
   assert.equal(outerContextMenuCount, 0, 'unrelated ancestor contextmenu handler should NOT fire on left-click trigger');
 });
+
+QUnit.test('hover trigger should not dispatch against a trigger removed from the document during its delay', function(assert) {
+  var done = assert.async();
+  var $fixture = $('#qunit-fixture');
+  if ($fixture.length === 0) {
+    $('<div id="qunit-fixture">').appendTo('body');
+    $fixture = $('#qunit-fixture');
+  }
+
+  $fixture.append('<span class="hover-trigger">hover me</span>');
+  var $trigger = $('.hover-trigger');
+
+  var menuOpenCount = 0;
+  $.contextMenu({
+    selector: '.hover-trigger',
+    trigger: 'hover',
+    delay: 10,
+    events: {
+      show: function() { menuOpenCount++; }
+    },
+    items: {
+      copy: {name: 'Copy'}
+    }
+  });
+
+  $trigger.trigger($.Event('mouseenter', {pageX: 0, pageY: 0}));
+  // remove the trigger from the document before the hover delay elapses
+  $trigger.remove();
+
+  setTimeout(function() {
+    assert.equal(menuOpenCount, 0, 'menu should not open for a trigger that was removed before the delay elapsed');
+    done();
+  }, 30);
+});

--- a/test/unit/issue-754-repro.test.js
+++ b/test/unit/issue-754-repro.test.js
@@ -1,0 +1,41 @@
+QUnit.module('issue 754 repro', {
+  afterEach: function() {
+    $.contextMenu('destroy');
+    var $fixture = $('#qunit-fixture');
+    if ($fixture.length) {
+      $fixture.html('');
+    }
+  }
+});
+
+QUnit.test('left-click trigger should not bubble a synthetic contextmenu event to unrelated ancestor handlers', function(assert) {
+  var $fixture = $('#qunit-fixture');
+  if ($fixture.length === 0) {
+    $('<div id="qunit-fixture">').appendTo('body');
+    $fixture = $('#qunit-fixture');
+  }
+
+  $fixture.append('<div class="outer-grid"><span class="left-trigger">left click me</span></div>');
+
+  var outerContextMenuCount = 0;
+  $('.outer-grid').on('contextmenu', function() {
+    outerContextMenuCount++;
+  });
+
+  var menuOpenCount = 0;
+  $.contextMenu({
+    selector: '.left-trigger',
+    trigger: 'left',
+    events: {
+      show: function() { menuOpenCount++; }
+    },
+    items: {
+      copy: {name: 'Copy'}
+    }
+  });
+
+  $('.left-trigger').trigger($.Event('click', {which: 1, button: 0}));
+
+  assert.equal(menuOpenCount, 1, 'sanity check: our own contextMenu opened once');
+  assert.equal(outerContextMenuCount, 0, 'unrelated ancestor contextmenu handler should NOT fire on left-click trigger');
+});


### PR DESCRIPTION
## Summary
Fixes #754. When a menu uses `trigger: 'left'` (also affects `'hover'`/`'touchstart'`), the plugin simulates a right-click by doing `$(this).trigger($.Event('contextmenu', ...))`. jQuery's `.trigger()` bubbles that synthetic event through every `contextmenu` handler bound on ancestor elements, not just the plugin's own delegated listener — so unrelated code elsewhere on the page (e.g. a grid component's own `contextmenu` handler) receives it and can't tell it apart from a real right-click.

Fix: in the three spots that synthesize a `contextmenu` event from a non-contextmenu native event (`handle.click`, `handle.mouseup`, `handle.mouseenter`), call the internal dispatcher directly (`handle.contextmenu.call(...)`) instead of triggering a bubbling event. Behavior and event data passed to the plugin are unchanged; it just no longer re-enters the DOM's bubbling chain.

## Test plan
- [x] Added a regression test binding a `contextmenu` handler on an unrelated ancestor and asserting it doesn't fire for a `trigger: 'left'` menu
- [x] `npm run test-unit` — 28/28 pass
- [x] `npm run test-accept` (Playwright) — 10/10 pass