### PR TITLE
docs: document custom SVG icons without a gulp build step

### DIFF
--- a/documentation/docs/customize.md
+++ b/documentation/docs/customize.md
@@ -25,6 +25,30 @@ Font-Awesome icons used from [encharm/Font-Awesome-SVG-PNG](https://github.com/e
 
 Finally, you will need to re-build the CSS using [`sass`](http://sass-lang.com), otherwise you may see mismatchings between the icon references. Use the command ``gulp css`` to re-build the CSS in the dist directory. The new CSS files will contain the icons you added.
 
+### Using your own SVG icons without a build step
+
+The `gulp build-icons` pipeline above compiles the SVGs in `src/icons` into an icon font, which is meant for icons you want bundled into this package's own build. If you just want to use your own SVG icons in your project, you don't need to fork or build anything, since the [icon option](items#icon) already supports both of the following, plain CSS approaches:
+
+```javascript
+var items = {
+    firstCommand: {
+        name: "Paste",
+        // context-menu-icon-checkmark must be defined in your own CSS, e.g.
+        // .context-menu-icon-checkmark { background-image: url(checkmark.svg); }
+        icon: "checkmark"
+    },
+    secondCommand: {
+        name: "Copy",
+        // or inject an inline <svg> (or <img>) directly into the item and
+        // return a class name to mark it as done (see the icon option docs)
+        icon: function (opt, $itemElement) {
+            $itemElement.prepend('<svg class="context-menu-icon" ...>...</svg>');
+            return 'context-menu-icon-inline';
+        }
+    }
+}
+```
+
 ## Customize CSS
 
 You can use the _variables.scss to adjust variables on pretty much everything you want to change.


### PR DESCRIPTION
## Summary
Addresses #762. The reporter (and `splitbrain` in the comments) wanted to use their own SVG icons without going through the `src/icons` → `gulp build-icons` → `gulp css` pipeline, which is meant for icons bundled into this package's own build/fork — not something most consumers should need to do.

That's already possible today: the [`icon` option](https://swisnl.github.io/jQuery-contextMenu/docs/items#icon) accepts either a plain CSS class (which you define yourself, e.g. via `background-image`) or a function that can inject inline SVG markup directly into the item. `customize.md` just never mentioned this, so it only pointed people at the heavyweight build/fork path.

This PR adds a short "Using your own SVG icons without a build step" section documenting both approaches, matching the existing icon-function example style already used in `items.md`.

(The npm-install/build breakage originally reported in #762 was unrelated tooling drift and is already fixed on current master — verified separately.)

## Test plan
- [x] `npm run docs:build` — site builds cleanly, new section renders correctly in `documentation/_site/docs/customize.html`