### PR TITLE
feat: support function-based item.name for dynamic menu labels

### DIFF
--- a/documentation/docs/items.md
+++ b/documentation/docs/items.md
@@ -50,7 +50,9 @@ Check out the [demo using a promise](demo/async-promise.md) for an example how t
 
 Specify the human readable name of the command in the menu. This is used as the label for the option.
 
-`name`: `string`
+May be a callback returning a `string`, so the label can be updated at runtime (e.g. via `$.contextMenu('update')`). The callback receives the same arguments as [`icon`](#icon), and is re-evaluated whenever the menu is created or updated.
+
+`name`: `string` or `function(opt, $itemElement, itemKey, item)`
 
 #### Example
 
@@ -58,6 +60,12 @@ Specify the human readable name of the command in the menu. This is used as the 
 var items = {
     firstCommand: {
         name: "Copy"
+    },
+    secondCommand: {
+        name: function(opt, $itemElement, itemKey, item){
+            // Compute the label dynamically, e.g. based on some external state.
+            return isEnabled ? "Disable" : "Enable";
+        }
     }
 }
 ```

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1342,7 +1342,7 @@
                     root.accesskeys = {};
                 }
 
-                function createNameNode(item) {
+                function createNameNode(item, $t, key) {
                     var $name = $('<span></span>');
                     if (item._accesskey) {
                         if (item._beforeAccesskey) {
@@ -1356,16 +1356,27 @@
                             $name.append(document.createTextNode(item._afterAccesskey));
                         }
                     } else {
+                        // just like `icon`, `name` may be a function returning the
+                        // current label to display. Called with the same signature
+                        // and context icon uses at creation time, so the two stay
+                        // consistent for anyone already using function-based icons.
+                        item._name = (typeof item.name === 'function') ?
+                            item.name.call(item, item, $t, key, item) :
+                            item.name;
+
                         if (item.isHtmlName) {
                             // restrict use with access keys
                             if (typeof item.accesskey !== 'undefined') {
                                 throw new Error('accesskeys are not compatible with HTML names and cannot be used together in the same item');
                             }
-                            $name.html(item.name);
+                            $name.html(item._name);
                         } else {
-                            $name.text(item.name);
+                            $name.text(item._name);
                         }
                     }
+                    // cache so op.update() can refresh the label in place when
+                    // `name` is a function (see the icon._icon handling below).
+                    item.$name = $name;
                     return $name;
                 }
 
@@ -1399,11 +1410,17 @@
                         for (var i = 0, ak; (ak = aks[i]); i++) {
                             if (!root.accesskeys[ak]) {
                                 root.accesskeys[ak] = item;
-                                var matched = item.name.match(new RegExp('^(.*?)(' + ak + ')(.*)$', 'i'));
-                                if (matched) {
-                                    item._beforeAccesskey = matched[1];
-                                    item._accesskey = matched[2];
-                                    item._afterAccesskey = matched[3];
+                                // accesskey highlighting needs a static string to search
+                                // within; a function-based name has no fixed text to
+                                // match against, so it's just skipped (the item still
+                                // reserves the accesskey, it just won't be highlighted).
+                                if (typeof item.name === 'string') {
+                                    var matched = item.name.match(new RegExp('^(.*?)(' + ak + ')(.*)$', 'i'));
+                                    if (matched) {
+                                        item._beforeAccesskey = matched[1];
+                                        item._accesskey = matched[2];
+                                        item._afterAccesskey = matched[3];
+                                    }
                                 }
                                 break;
                             }
@@ -1430,7 +1447,7 @@
                             $t.addClass('context-menu-html ' + root.classNames.notSelectable);
                         } else if (item.type !== 'sub' && item.type) {
                             $label = $('<label></label>').appendTo($t);
-                            createNameNode(item).appendTo($label);
+                            createNameNode(item, $t, key).appendTo($label);
 
                             $t.addClass('context-menu-input');
                             opt.hasTypes = true;
@@ -1497,7 +1514,7 @@
                                 break;
 
                             case 'sub':
-                                createNameNode(item).appendTo($t);
+                                createNameNode(item, $t, key).appendTo($t);
                                 item.appendTo = item.$node;
                                 $t.data('contextMenu', item).addClass('context-menu-submenu');
                                 item.callback = null;
@@ -1527,7 +1544,7 @@
                                         k.callbacks[key] = item.callback;
                                     }
                                 });
-                                createNameNode(item).appendTo($t);
+                                createNameNode(item, $t, key).appendTo($t);
                                 break;
                         }
 
@@ -1771,6 +1788,20 @@
                             $item.addClass(iconResult);
                         } else {
                             $item.prepend(iconResult);
+                        }
+                    }
+
+                    // re-evaluate a function-based `name` on every update, same as
+                    // `icon`/`disabled` above, so a dynamic label reflects current
+                    // state instead of only whatever it resolved to at creation.
+                    if (typeof item.name === 'function') {
+                        item._name = item.name.call(this, $trigger, $item, key, item);
+                        if (item.$name && item.$name.length) {
+                            if (item.isHtmlName) {
+                                item.$name.html(item._name);
+                            } else {
+                                item.$name.text(item._name);
+                            }
                         }
                     }
 

--- a/test/unit/contextmenu.test.js
+++ b/test/unit/contextmenu.test.js
@@ -304,6 +304,40 @@ function testQUnit(name, itemClickEvent, triggerEvent) {
         assert.equal($item.find('i.fa.fa-trash').length, 1, 'FontAwesome <i> tag was not created for legacy "fa-*" icon shorthand');
         assert.notOk($item.hasClass('fa') || $item.hasClass('fa-trash'), 'FontAwesome classes should not be applied to the menu item itself, as that bleeds the icon font (and its font-weight) into the item label text');
     });
+
+    QUnit.test('name as a function renders a dynamic label and re-evaluates on update, like icon/disabled', function(assert) {
+        // Regression test for https://github.com/swisnl/jQuery-contextMenu/issues/743
+        // "How to change the label at runtime?" - item.icon and item.disabled
+        // already support being a function that's re-invoked whenever the menu
+        // is updated, but item.name did not: it was always rendered as static
+        // content, with no way for a menu item's label to reflect changing
+        // external state.
+        var state = 'Enable feature';
+
+        createContextMenu({
+            toggle: {
+                name: function() {
+                    return state;
+                },
+                icon: 'copy'
+            }
+        });
+
+        $(".context-menu").contextMenu();
+
+        var $item = $('.context-menu-item').first();
+
+        assert.equal($item.text().trim(), 'Enable feature', 'label reflects the function\'s return value on initial render');
+
+        // mutate the external state the function reads from, then ask the
+        // plugin to refresh - the same mechanism icon/disabled rely on to
+        // pick up new values (see the "visible function should only trigger
+        // once" test above for the same update path).
+        state = 'Disable feature';
+        $.contextMenu('update');
+
+        assert.equal($item.text().trim(), 'Disable feature', 'label updates to reflect the function\'s new return value after update');
+    });
 }
 
 testQUnit('contextMenu events', '', 'mouseup');


### PR DESCRIPTION
Closes #743

## Problem

`item.icon` and `item.disabled` already support being a function that's re-evaluated on every menu render/update, but `item.name` did not - it was always rendered once as static content. There was no supported way to change a menu item's label at runtime based on external state (the issue reporter needed this alongside their already-dynamic `icon`/`disabled` functions).

## Fix

`item.name` now also accepts a function, matching `icon`'s documented signature: `function(opt, $itemElement, itemKey, item)`. It's wired into the exact same render path as `icon`:

- At menu creation (`createNameNode`), the function is invoked once to produce the initial label.
- At `op.update()` (the same path that re-invokes `icon`/`disabled`), the function is invoked again and the cached `$name` node's text/html is refreshed in place - so calling `$.contextMenu('update')` (or anything else that triggers an update, e.g. hovering into a submenu) picks up a new label just like it already does for icons and disabled state.

A minor edge case: `accesskey` matching needs a static string to search within for the underlined access-key character. If `name` is a function, that regex match is skipped (the accesskey is still reserved, it just won't be visually highlighted) - functions and static accesskey text can't really coexist, so this seemed like the least surprising behavior rather than throwing.

## Tests

- Added a QUnit regression test (`test/unit/contextmenu.test.js`) asserting the rendered label reflects a `name` function's return value, then mutates the backing state and asserts it updates after `$.contextMenu('update')`, mirroring how `visible`/`icon` are exercised elsewhere in that file.
- Verified the new test fails without the source fix (only the initial-render assertion passes, since jQuery's `.text()` happens to accept a function too; the post-update assertion fails as expected) and passes with it.
- `npm run test-unit` - 33/33 passing (also re-verified against jQuery 1.12.4 locally).
- `npm run test:fixtures && npx playwright test` - 15/15 passing, no regressions.

## Docs

Updated `documentation/docs/items.md`'s `name` section to document the function form, consistent with how `icon`/`disabled` are documented there.

`dist/` was intentionally left untouched per project convention (rebuilt via `prepublishOnly`).