### PR TITLE
feat: allow selector to be an Element or jQuery object

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,25 @@ $.contextMenu({
 });
 ```
 
+`selector` usually is a CSS selector string, delegated the same way as `$(document).on(event, selector, ...)`. It can also be a raw `Element` or a jQuery object, which is useful for elements that were created programmatically and aren't (yet) matched by a stable selector:
+
+```javascript
+var element = document.createElement('button');
+element.textContent = 'Click Me';
+
+$.contextMenu({
+    // bind directly to this element instead of delegating via a selector
+    selector: element, // or $(element)
+    items: {
+        foo: {name: "Foo", callback: function(key, opt){ alert("Foo!"); }}
+    }
+});
+
+document.body.appendChild(element);
+```
+
+Note: when `selector` is an `Element` or jQuery object, the contextMenu is bound directly to it rather than delegated, so registering with the exact same element again without destroying the previous registration first will bind a second, independent handler. Destroy it with `$.contextMenu('destroy', element)` (or `$.contextMenu('destroy', $(element))`) before re-registering.
+
 have a look at the [demos](http://swisnl.github.io/jQuery-contextMenu/demo.html).
 
 ## Version 3.0 beta

--- a/documentation/docs/plugin-commands.md
+++ b/documentation/docs/plugin-commands.md
@@ -59,7 +59,7 @@ To unregister / destroy a specific contextMenu:
 $.contextMenu( 'destroy', selector );
 ```
 
-selector expects the (string) selector that the contextMenu was registered to
+`selector` expects the same value the contextMenu was registered with: either the CSS selector string, or - if the contextMenu was registered with an `Element` or jQuery object as its `selector` - that same `Element` / jQuery object.
 
 ## Unregister all contextMenus
 

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -2036,6 +2036,20 @@
             (selector.nodeType === 1 || (typeof selector.jquery !== 'undefined' && typeof selector.length === 'number'));
     }
 
+    // remove every `elementSelectors` entry (and its bound handler) registered
+    // under the given namespace. Used to tear down direct element/jQuery-object
+    // bindings from any destroy code path, regardless of whether the menu was
+    // created with a custom `context`.
+    function teardownElementSelectorBindings(ns) {
+        for (var i = elementSelectors.length - 1; i >= 0; i--) {
+            if (elementSelectors[i].ns !== ns) {
+                continue;
+            }
+            $(elementSelectors[i].el).off(elementSelectors[i].ns);
+            elementSelectors.splice(i, 1);
+        }
+    }
+
 // handle contextMenu triggers
     $.fn.contextMenu = function (operation) {
         var $t = this, $o = operation;
@@ -2155,14 +2169,19 @@
                 }
                 counter++;
                 o.ns = '.contextMenu' + counter;
-                if (!_hasContext) {
-                    if (useElementSelector) {
-                        $elements.each(function () {
-                            elementSelectors.push({el: this, ns: o.ns});
-                        });
-                    } else {
-                        namespaces[o.selector] = o.ns;
-                    }
+                if (useElementSelector) {
+                    // Element/jQuery-object selectors are always bound directly
+                    // to the given element(s) (see below), regardless of
+                    // whether a custom `context` was supplied, so they must
+                    // always be tracked here too - otherwise a registration
+                    // made with a non-document `context` (e.g. via
+                    // `$(container).contextMenu({selector: element, ...})`)
+                    // could never be found and torn down again by destroy().
+                    $elements.each(function () {
+                        elementSelectors.push({el: this, ns: o.ns});
+                    });
+                } else if (!_hasContext) {
+                    namespaces[o.selector] = o.ns;
                 }
                 menus[o.ns] = o;
 
@@ -2292,6 +2311,11 @@
                         }
 
                         $(o.context).off(o.ns);
+                        // Element/jQuery-object selectors are bound directly to
+                        // the trigger element(s) rather than to `o.context`
+                        // (see the 'create' operation), so they need their own
+                        // teardown here too.
+                        teardownElementSelectorBindings(o.ns);
 
                         return true;
                     });

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -127,6 +127,11 @@
         namespaces = {},
         // mapping namespace to options
         menus = {},
+        // registrations keyed by raw DOM element rather than a selector
+        // string - used when `selector` is an Element or jQuery object,
+        // since those can't be used as `namespaces` object keys the way
+        // selector strings are. Array of {el: DOMElement, ns: String}.
+        elementSelectors = [],
         // custom command type handlers
         types = {},
         // default values
@@ -2021,6 +2026,16 @@
         return keys;
     }
 
+    // is the given contextMenu `selector` option an Element or jQuery object,
+    // rather than a CSS selector string? Elements/jQuery objects can't be used
+    // as a delegated `.on()` selector argument (jQuery only delegates via CSS
+    // selector strings), so they're bound directly instead - see
+    // `elementSelectors` and the 'create'/'destroy' operations below.
+    function isElementSelector(selector) {
+        return !!selector && typeof selector === 'object' &&
+            (selector.nodeType === 1 || (typeof selector.jquery !== 'undefined' && typeof selector.length === 'number'));
+    }
+
 // handle contextMenu triggers
     $.fn.contextMenu = function (operation) {
         var $t = this, $o = operation;
@@ -2085,6 +2100,9 @@
             options = {selector: options};
         } else if (typeof options === 'undefined') {
             options = {};
+        } else if (isElementSelector(options)) {
+            // e.g. $.contextMenu('destroy', element) / $.contextMenu('destroy', $(element))
+            options = {selector: options};
         }
 
         // merge with default options
@@ -2092,6 +2110,12 @@
         var $document = $(document);
         var $context = $document;
         var _hasContext = false;
+
+        // an Element / jQuery object can't be used as a delegated-event
+        // selector string, so it's normalized here once and handled
+        // separately by the 'create'/'destroy' operations below.
+        var useElementSelector = isElementSelector(o.selector);
+        var $elements = useElementSelector ? (o.selector.jquery ? o.selector : $(o.selector)) : null;
 
         if (!o.context || !o.context.length) {
             o.context = document;
@@ -2119,11 +2143,11 @@
 
             case 'create':
                 // no selector no joy
-                if (!o.selector) {
+                if (!o.selector || (useElementSelector && $elements.length === 0)) {
                     throw new Error('No selector specified');
                 }
                 // make sure internal classes are not bound to
-                if (o.selector.match(/.context-menu-(list|item|input)($|\s)/)) {
+                if (!useElementSelector && o.selector.match(/.context-menu-(list|item|input)($|\s)/)) {
                     throw new Error('Cannot bind to selector "' + o.selector + '" as it contains a reserved className');
                 }
                 if (!o.build && (!o.items || $.isEmptyObject(o.items))) {
@@ -2132,7 +2156,13 @@
                 counter++;
                 o.ns = '.contextMenu' + counter;
                 if (!_hasContext) {
-                    namespaces[o.selector] = o.ns;
+                    if (useElementSelector) {
+                        $elements.each(function () {
+                            elementSelectors.push({el: this, ns: o.ns});
+                        });
+                    } else {
+                        namespaces[o.selector] = o.ns;
+                    }
                 }
                 menus[o.ns] = o;
 
@@ -2170,8 +2200,15 @@
                 }
 
                 // engage native contextmenu event
-                $context
-                    .on('contextmenu' + o.ns, o.selector, o, handle.contextmenu);
+                if (useElementSelector) {
+                    // Elements/jQuery objects aren't valid delegated-event
+                    // selectors, so bind directly to the given element(s)
+                    // instead of delegating through $context.
+                    $elements.on('contextmenu' + o.ns, o, handle.contextmenu);
+                } else {
+                    $context
+                        .on('contextmenu' + o.ns, o.selector, o, handle.contextmenu);
+                }
 
                 if (_hasContext) {
                     // add remove hook, just in case
@@ -2182,16 +2219,30 @@
 
                 switch (o.trigger) {
                     case 'hover':
-                        $context
-                            .on('mouseenter' + o.ns, o.selector, o, handle.mouseenter)
-                            .on('mouseleave' + o.ns, o.selector, o, handle.mouseleave);
+                        if (useElementSelector) {
+                            $elements
+                                .on('mouseenter' + o.ns, o, handle.mouseenter)
+                                .on('mouseleave' + o.ns, o, handle.mouseleave);
+                        } else {
+                            $context
+                                .on('mouseenter' + o.ns, o.selector, o, handle.mouseenter)
+                                .on('mouseleave' + o.ns, o.selector, o, handle.mouseleave);
+                        }
                         break;
 
                     case 'left':
-                        $context.on('click' + o.ns, o.selector, o, handle.click);
+                        if (useElementSelector) {
+                            $elements.on('click' + o.ns, o, handle.click);
+                        } else {
+                            $context.on('click' + o.ns, o.selector, o, handle.click);
+                        }
                         break;
 				    case 'touchstart':
-                        $context.on('touchstart' + o.ns, o.selector, o, handle.click);
+                        if (useElementSelector) {
+                            $elements.on('touchstart' + o.ns, o, handle.click);
+                        } else {
+                            $context.on('touchstart' + o.ns, o.selector, o, handle.click);
+                        }
                         break;
                     /*
                      default:
@@ -2249,13 +2300,46 @@
                     $.each(menus, function (ns, o) {
                         $(o.context).off(o.ns);
                     });
+                    $.each(elementSelectors, function (i, entry) {
+                        $(entry.el).off(entry.ns);
+                    });
 
                     namespaces = {};
                     menus = {};
+                    elementSelectors = [];
                     counter = 0;
                     initialized = false;
 
                     $('#context-menu-layer, .context-menu-list').remove();
+                } else if (useElementSelector) {
+                    $elements.each(function () {
+                        var el = this;
+                        for (var i = elementSelectors.length - 1; i >= 0; i--) {
+                            if (elementSelectors[i].el !== el) {
+                                continue;
+                            }
+
+                            var ns = elementSelectors[i].ns;
+
+                            $visibleMenu = $('.context-menu-list').filter(':visible');
+                            if ($visibleMenu.length && $visibleMenu.data().contextMenuRoot.$trigger.is(el)) {
+                                $visibleMenu.trigger('contextmenu:hide', {force: true});
+                            }
+
+                            try {
+                                if (menus[ns] && menus[ns].$menu) {
+                                    menus[ns].$menu.remove();
+                                }
+
+                                delete menus[ns];
+                            } catch (e) {
+                                menus[ns] = null;
+                            }
+
+                            $(el).off(ns);
+                            elementSelectors.splice(i, 1);
+                        }
+                    });
                 } else if (namespaces[o.selector]) {
                     $visibleMenu = $('.context-menu-list').filter(':visible');
                     if ($visibleMenu.length && $visibleMenu.data().contextMenuRoot.$trigger.is(o.selector)) {

--- a/test/unit/issue-748-element-selector.test.js
+++ b/test/unit/issue-748-element-selector.test.js
@@ -152,3 +152,85 @@ QUnit.test('global destroy (no selector) also tears down Element-based registrat
   assert.notOk(didThrow, 'triggering contextmenu after a global destroy did not throw');
   assert.equal(menuOpenCount, 0, 'contextMenu did not open after a global destroy');
 });
+
+QUnit.test('element selector combined with a custom context (via $(container).contextMenu()) is torn down by a global destroy', function(assert) {
+  // Regression test for a gap flagged during PR review for
+  // https://github.com/swisnl/jQuery-contextMenu/issues/748: when an
+  // Element/jQuery-object selector is registered together with a
+  // non-document `context` - as happens with the `$(container).contextMenu({...})`
+  // jQuery-fn shorthand, which sets `context` to the container - the direct
+  // binding on the element must still be tracked so a later destroy can find
+  // and remove it. It must not become permanently unremovable.
+  var container = document.createElement('div');
+  var element = document.createElement('button');
+  container.appendChild(element);
+
+  var $fixture = $('#qunit-fixture');
+  if ($fixture.length === 0) {
+    $('<div id="qunit-fixture">').appendTo('body');
+    $fixture = $('#qunit-fixture');
+  }
+  $fixture.append(container);
+
+  var menuOpenCount = 0;
+  $(container).contextMenu({
+    selector: element,
+    events: {
+      show: function() { menuOpenCount++; }
+    },
+    items: {
+      copy: {name: 'Copy'}
+    }
+  });
+
+  $(element).trigger($.Event('contextmenu'));
+  assert.equal(menuOpenCount, 1, 'contextMenu opened for an Element selector registered with a custom context');
+
+  // A subsequent *global* destroy (no selector, no context) must also tear
+  // down this direct binding.
+  $.contextMenu('destroy');
+
+  menuOpenCount = 0;
+  var didThrow = false;
+  try {
+    $(element).trigger($.Event('contextmenu'));
+  } catch (e) {
+    didThrow = true;
+  }
+
+  assert.notOk(didThrow, 'triggering contextmenu after a global destroy did not throw');
+  assert.equal(menuOpenCount, 0, 'contextMenu no longer opens after a global destroy, even though it was registered with a custom context');
+});
+
+QUnit.test('element selector combined with a custom context can be destroyed directly by element', function(assert) {
+  var container = document.createElement('div');
+  var element = document.createElement('button');
+  container.appendChild(element);
+
+  var $fixture = $('#qunit-fixture');
+  if ($fixture.length === 0) {
+    $('<div id="qunit-fixture">').appendTo('body');
+    $fixture = $('#qunit-fixture');
+  }
+  $fixture.append(container);
+
+  var menuOpenCount = 0;
+  $(container).contextMenu({
+    selector: element,
+    events: {
+      show: function() { menuOpenCount++; }
+    },
+    items: {
+      copy: {name: 'Copy'}
+    }
+  });
+
+  $(element).trigger($.Event('contextmenu'));
+  assert.equal(menuOpenCount, 1, 'sanity check: contextMenu opened once before destroy');
+
+  $.contextMenu('destroy', element);
+
+  menuOpenCount = 0;
+  $(element).trigger($.Event('contextmenu'));
+  assert.equal(menuOpenCount, 0, 'contextMenu no longer opens after being destroyed directly by element, even though it was registered with a custom context');
+});

--- a/test/unit/issue-748-element-selector.test.js
+++ b/test/unit/issue-748-element-selector.test.js
@@ -1,0 +1,154 @@
+QUnit.module('issue 748 - Element/jQuery object as selector', {
+  afterEach: function() {
+    $.contextMenu('destroy');
+    var $fixture = $('#qunit-fixture');
+    if ($fixture.length) {
+      $fixture.html('');
+    }
+  }
+});
+
+QUnit.test('selector can be a raw, not-yet-attached DOM Element', function(assert) {
+  // Regression test for https://github.com/swisnl/jQuery-contextMenu/issues/748
+  // Mirrors the issue's example: create the element first, register the
+  // contextMenu against the element itself (not a CSS selector), and only
+  // then insert it into the document.
+  var element = document.createElement('button');
+  element.textContent = 'Click Me';
+
+  var menuOpenCount = 0;
+  $.contextMenu({
+    selector: element,
+    events: {
+      show: function() { menuOpenCount++; }
+    },
+    items: {
+      copy: {name: 'Copy'}
+    }
+  });
+
+  var $fixture = $('#qunit-fixture');
+  if ($fixture.length === 0) {
+    $('<div id="qunit-fixture">').appendTo('body');
+    $fixture = $('#qunit-fixture');
+  }
+  $fixture.append(element);
+
+  $(element).trigger($.Event('contextmenu'));
+
+  assert.equal(menuOpenCount, 1, 'contextMenu opened for an Element-based selector');
+
+  var didThrow = false;
+  try {
+    $.contextMenu('destroy', element);
+  } catch (e) {
+    didThrow = true;
+  }
+  assert.notOk(didThrow, 'destroying by Element did not throw');
+
+  menuOpenCount = 0;
+  $(element).trigger($.Event('contextmenu'));
+  assert.equal(menuOpenCount, 0, 'contextMenu no longer opens after being destroyed');
+});
+
+QUnit.test('selector can be a jQuery-wrapped Element', function(assert) {
+  var element = document.createElement('button');
+  var $fixture = $('#qunit-fixture');
+  if ($fixture.length === 0) {
+    $('<div id="qunit-fixture">').appendTo('body');
+    $fixture = $('#qunit-fixture');
+  }
+  $fixture.append(element);
+
+  var menuOpenCount = 0;
+  $.contextMenu({
+    selector: $(element),
+    events: {
+      show: function() { menuOpenCount++; }
+    },
+    items: {
+      copy: {name: 'Copy'}
+    }
+  });
+
+  $(element).trigger($.Event('contextmenu'));
+  assert.equal(menuOpenCount, 1, 'contextMenu opened for a jQuery-object selector');
+
+  $.contextMenu('destroy', $(element));
+
+  menuOpenCount = 0;
+  $(element).trigger($.Event('contextmenu'));
+  assert.equal(menuOpenCount, 0, 'contextMenu no longer opens after being destroyed via jQuery-object selector');
+});
+
+QUnit.test('destroy + re-registration on the same Element does not throw or double-bind', function(assert) {
+  var element = document.createElement('button');
+  var $fixture = $('#qunit-fixture');
+  if ($fixture.length === 0) {
+    $('<div id="qunit-fixture">').appendTo('body');
+    $fixture = $('#qunit-fixture');
+  }
+  $fixture.append(element);
+
+  var menuOpenCount = 0;
+  var register = function() {
+    $.contextMenu({
+      selector: element,
+      events: {
+        show: function() { menuOpenCount++; }
+      },
+      items: {
+        copy: {name: 'Copy'}
+      }
+    });
+  };
+
+  var didThrow = false;
+  try {
+    register();
+    $.contextMenu('destroy', element);
+    register();
+    $.contextMenu('destroy', element);
+    register();
+  } catch (e) {
+    didThrow = true;
+  }
+
+  assert.notOk(didThrow, 'repeated destroy/re-register cycles on the same Element did not throw');
+
+  $(element).trigger($.Event('contextmenu'));
+  assert.equal(menuOpenCount, 1, 'contextMenu opened exactly once (no leftover double-bound handlers from earlier registrations)');
+});
+
+QUnit.test('global destroy (no selector) also tears down Element-based registrations', function(assert) {
+  var element = document.createElement('button');
+  var $fixture = $('#qunit-fixture');
+  if ($fixture.length === 0) {
+    $('<div id="qunit-fixture">').appendTo('body');
+    $fixture = $('#qunit-fixture');
+  }
+  $fixture.append(element);
+
+  var menuOpenCount = 0;
+  $.contextMenu({
+    selector: element,
+    events: {
+      show: function() { menuOpenCount++; }
+    },
+    items: {
+      copy: {name: 'Copy'}
+    }
+  });
+
+  $.contextMenu('destroy');
+
+  var didThrow = false;
+  try {
+    $(element).trigger($.Event('contextmenu'));
+  } catch (e) {
+    didThrow = true;
+  }
+
+  assert.notOk(didThrow, 'triggering contextmenu after a global destroy did not throw');
+  assert.equal(menuOpenCount, 0, 'contextMenu did not open after a global destroy');
+});


### PR DESCRIPTION
Closes #748

## What

`$.contextMenu({ selector })` previously had to be a CSS selector string. This adds support for passing a raw `Element` or a jQuery object as `selector`, so context menus can be attached to elements created programmatically before they're inserted into the DOM (or otherwise not addressable by a stable selector).

```javascript
const element = document.createElement('button');
element.textContent = 'Click Me';

$.contextMenu({
    selector: element, // or $(element)
    items: {
        foo: { name: 'Foo', callback: function () { alert('Foo!'); } }
    }
});

document.body.appendChild(element);
```

## Why this needed more than "just pass it through"

`selector` is used pervasively as a *string*:
- `namespaces[o.selector] = o.ns` — used as an object key for `update()`/`destroy()` lookups.
- `.on('contextmenu' + o.ns, o.selector, o, handler)` — jQuery delegated binding requires a selector *string* for the delegation argument; jQuery doesn't support delegating via a raw Element/jQuery object.
- A reserved-classname guard (`o.selector.match(...)`) that assumes a string.

## Approach

- When `selector` is an Element or jQuery object, events are bound **directly** to the element(s) instead of delegating through the document/context (delegation-by-element isn't meaningful the way delegation-by-selector is). This also means the menu can be registered before the element is inserted into the DOM, matching the issue's example.
- Added a parallel `elementSelectors` registry (an array of `{el, ns}` pairs, matched by element identity) alongside the existing string-keyed `namespaces` map, so `destroy()` (both `$.contextMenu('destroy', element)` and the global `$.contextMenu('destroy')`) correctly tears down element-based registrations too.
- String selectors are completely unaffected — same delegated binding, same `namespaces` behavior as before.

## Scope / what's NOT covered

This is intentionally a minimal implementation covering the case from the issue:
- A single `Element`, or a jQuery object wrapping one or more elements — bound directly (non-delegated).
- Re-registering the *exact same* element without destroying the previous registration first will bind an additional, independent handler (same as what already happens today if you register the same string selector twice) — destroy first if you want a clean re-registration.

## Tests

- Added `test/unit/issue-748-element-selector.test.js` covering: a not-yet-attached `Element` as `selector`, a jQuery-wrapped element, destroy + re-registration on the same element (no throw / no double-bind), and that the global `destroy()` also tears down element-based registrations.
- `npm run test-unit` (karma + qunit, ChromeHeadless): 35/35 passing.
- `npm run test:fixtures && npx playwright test`: 15/15 passing, no regressions.

## Docs

Updated `README.md` and `documentation/docs/plugin-commands.md` to document the new supported `selector` types and the destroy-by-element usage.

Per project convention, `dist/` is rebuilt at publish time (`prepublishOnly`) and is intentionally not touched in this PR.