### PR TITLE
feat: add direction option for RTL menu support

### DIFF
--- a/documentation/demo/rtl-long-submenu.md
+++ b/documentation/demo/rtl-long-submenu.md
@@ -1,0 +1,55 @@
+---
+currentMenu: rtl-long-submenu
+---
+
+# Demo: RTL menu with a long (overflowing) sub-menu
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [Example code](#example-code)
+- [Example HTML](#example-html)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<span class="context-menu-one btn btn-neutral">right click me</span>
+
+## Example code
+
+<script type="text/javascript" class="showcase">
+$(function(){
+    /**************************************************
+     * Combined regression coverage for `direction: 'rtl'`
+     * (#742) together with a sub-menu taller than the
+     * viewport (#752): the sub-menu must still open on
+     * the LEFT of its parent item (RTL) AND be detached,
+     * capped to the viewport and scrollable, exactly like
+     * the plain LTR case in long-submenu-short-root.md.
+     **************************************************/
+    var subItems = {};
+    for (var i = 1; i <= 40; i++) {
+        subItems['sub-key' + i] = {name: 'Sub item ' + i};
+    }
+
+    $.contextMenu({
+        selector: '.context-menu-one',
+        direction: 'rtl',
+        callback: function(key, options) {
+            var m = "clicked: " + key;
+            window.console && console.log(m) || alert(m);
+        },
+        items: {
+            item1: {name: 'Item 1'},
+            item2: {name: 'Item 2'},
+            fold1: {
+                name: 'Long sub group',
+                items: subItems
+            }
+        }
+    });
+});
+</script>
+
+## Example HTML
+<div style="display:none;" class="showcase" data-showcase-import=".context-menu-one"></div>

--- a/documentation/docs.md
+++ b/documentation/docs.md
@@ -22,6 +22,7 @@ title: jQuery contextMenu — Documentation
   - [zIndex](#zindex)
   - [className](#classname)
   - [classNames](#classnames)
+  - [direction](#direction)
   - [animation](#animation)
   - [events](#events)
   - [position](#position)
@@ -282,6 +283,34 @@ var options = {
     
     }
 }
+```
+
+### direction
+
+Specifies the text direction of the menu. Set to `'rtl'` for right-to-left languages (e.g. Arabic, Hebrew). This adds a `context-menu-rtl` class to the menu and its sub-menus, which right-aligns text and mirrors icon and submenu-arrow placement, and flips the side sub-menus open on so they expand to the *left* of their parent item instead of the right.
+
+`direction`: `string` default: `'ltr'`
+
+Value | Description
+---- | ----
+`ltr` | Left-to-right (default)
+`rtl` | Right-to-left
+
+#### Example
+```javascript
+$.contextMenu({
+    selector: 'span.context-menu',
+    direction: 'rtl',
+    items: {
+        edit: {name: 'Edit'},
+        more: {
+            name: 'More',
+            items: {
+                foo: {name: 'Foo'}
+            }
+        }
+    }
+});
 ```
 
 

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -155,6 +155,11 @@
             //ability to select submenu
             selectableSubMenu: false,
 
+            // text direction of the menu, use 'rtl' for right-to-left languages.
+            // adds a `context-menu-rtl` class to the menu and flips the side
+            // sub-menus open on.
+            direction: 'ltr',
+
             // Default classname configuration to be able avoid conflicts in frameworks
             classNames: {
                 hover: 'context-menu-hover', // Item hover
@@ -242,6 +247,10 @@
                     // call positionSubmenu after promise is completed.
                     return;
                 }
+                // in 'rtl' mode sub-menus open to the left of their parent
+                // item instead of the right (see op.create / opt.direction).
+                var root = $menu.data('contextMenuRoot'),
+                    isRtl = !!root && root.direction === 'rtl';
                 if ($menu.hasClass('context-menu-detached')) {
                     // This sub-menu was moved out to <body> (see op.detachSubmenus)
                     // because its parent menu is scrollable and would otherwise
@@ -251,11 +260,18 @@
                     var itemOffset = this.offset(),
                         menuWidth = $menu.outerWidth() || $menu.width(),
                         menuHeight = $menu.outerHeight() || $menu.height(),
-                        left = itemOffset.left + this.outerWidth() - 5,
+                        left = isRtl ?
+                            itemOffset.left - menuWidth + 5 :
+                            itemOffset.left + this.outerWidth() - 5,
                         top = itemOffset.top - 9,
                         maxTop = $win.scrollTop() + $win.height() - menuHeight;
 
-                    if (left + menuWidth > $win.scrollLeft() + $win.width()) {
+                    if (isRtl) {
+                        if (left < $win.scrollLeft()) {
+                            // doesn't fit to the left of the item, flip to the right
+                            left = itemOffset.left + this.outerWidth() - 5;
+                        }
+                    } else if (left + menuWidth > $win.scrollLeft() + $win.width()) {
                         // doesn't fit to the right of the item, flip to the left
                         left = itemOffset.left - menuWidth + 5;
                     }
@@ -276,14 +292,17 @@
                     // .position() is provided as a jQuery UI utility
                     // (...and it won't work on hidden elements)
                     $menu.css('display', 'block').position({
-                        my: 'left top-5',
-                        at: 'right top',
+                        my: isRtl ? 'right top-5' : 'left top-5',
+                        at: isRtl ? 'left top' : 'right top',
                         of: this,
                         collision: 'flipfit fit'
                     }).css('display', '');
                 } else {
                     // determine contextMenu position
-                    var offset = {
+                    var offset = isRtl ? {
+                        top: -9,
+                        left: -(($menu.outerWidth() || $menu.width()) - 5)
+                    } : {
                         top: -9,
                         left: this.outerWidth() - 5
                     };
@@ -1325,6 +1344,13 @@
                     'contextMenu': opt,
                     'contextMenuRoot': root
                 });
+                if (root.direction === 'rtl') {
+                    // applied to every menu/sub-menu, not just the root, so
+                    // detached sub-menus (see op.detachSubmenus) that get
+                    // moved out to <body> keep the styling even though
+                    // they're no longer a CSS descendant of the root menu.
+                    opt.$menu.addClass('context-menu-rtl');
+                }
                 if(opt.dataAttr){
                     $.each(opt.dataAttr, function (key, item) {
                         opt.$menu.attr('data-' + opt.key, item);

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -270,6 +270,12 @@
                         if (left < $win.scrollLeft()) {
                             // doesn't fit to the left of the item, flip to the right
                             left = itemOffset.left + this.outerWidth() - 5;
+                            // ...and if it doesn't fit there either (viewport
+                            // narrower than the menu), clamp against the
+                            // right edge rather than leaving it hanging off.
+                            if (left + menuWidth > $win.scrollLeft() + $win.width()) {
+                                left = $win.scrollLeft() + $win.width() - menuWidth;
+                            }
                         }
                     } else if (left + menuWidth > $win.scrollLeft() + $win.width()) {
                         // doesn't fit to the right of the item, flip to the left

--- a/src/sass/jquery.contextMenu.scss
+++ b/src/sass/jquery.contextMenu.scss
@@ -208,3 +208,44 @@
 .context-menu-accesskey {
   text-decoration: underline;
 }
+
+/**
+ * RTL support (see the `direction` option in jquery.contextMenu.js).
+ * Mirrors text alignment, icon placement and the submenu-arrow/opening side.
+ * Applied to every menu/sub-menu (not just the root) so detached sub-menus
+ * (see op.detachSubmenus, #775) keep the styling even when they're moved
+ * out of the root menu's DOM subtree.
+ */
+.context-menu-list.context-menu-rtl {
+  direction: rtl;
+  text-align: right;
+}
+
+.context-menu-rtl .context-menu-icon::before {
+  left: auto;
+  right: 0;
+}
+
+.context-menu-rtl .context-menu-icon--fa5 i,
+.context-menu-rtl .context-menu-icon--fa5 svg {
+  left: auto;
+  right: 0.5em;
+}
+
+.context-menu-rtl .context-menu-input > label > input[type="checkbox"],
+.context-menu-rtl .context-menu-input > label > input[type="radio"] {
+  margin-right: 0;
+  margin-left: .4em;
+}
+
+.context-menu-rtl .context-menu-submenu:after {
+  right: auto;
+  left: .5em;
+  border-width: .25em .25em .25em 0;
+  border-color: transparent $context-menu-submenu-arrow-color transparent transparent;
+}
+
+.context-menu-item > .context-menu-list.context-menu-rtl {
+  right: auto;
+  left: -.3em;
+}

--- a/test/specs/rtl-overflow-submenu.js
+++ b/test/specs/rtl-overflow-submenu.js
@@ -1,0 +1,56 @@
+const { test, expect } = require('@playwright/test');
+const { fixture, expectAlert } = require('../support/helpers');
+
+// Regression test for the combination of `direction: 'rtl'` (#742) and a
+// sub-menu taller than the viewport (#752): these two features both modify
+// positionSubmenu() in src/jquery.contextMenu.js (see the merge commit that
+// combined them), so this exercises them together rather than trusting that
+// each one working in isolation (covered separately by
+// test/unit/direction-rtl.test.js and test/specs/overflow-submenu-only.js)
+// means the combined logic is also correct.
+test.describe('Test direction: "rtl" together with an overflowing sub-menu (#742 + #752)', () => {
+  test.use({ viewport: { width: 1000, height: 500 } });
+
+  test('an overflowing sub-menu still opens to the left in rtl mode, and is capped/scrollable', async ({ page }) => {
+    await page.goto(fixture('rtl-long-submenu.html'));
+    await page.click('.context-menu-one', { button: 'right' });
+
+    const menu = page.locator('.context-menu-root');
+    await expect(menu).toBeVisible();
+    await expect(menu).toHaveClass(/context-menu-rtl/);
+
+    const opener = page.locator('span:text-is("Long sub group")');
+    const openerBox = await opener.boundingBox();
+
+    await opener.hover();
+
+    const submenu = page.locator('.context-menu-list:not(.context-menu-root)');
+    await expect(submenu).toBeVisible();
+    await expect(submenu).toHaveClass(/context-menu-rtl/);
+
+    const submenuBox = await submenu.boundingBox();
+
+    // rtl: the sub-menu should open to the LEFT of its opener, not the right
+    expect(submenuBox.x).toBeLessThanOrEqual(openerBox.x);
+
+    // ...and, despite opening on a different side, it must still be capped
+    // to the viewport height and made scrollable rather than clipped
+    // (the same #752 behaviour as the plain ltr case)
+    const viewportHeight = page.viewportSize().height;
+    expect(submenuBox.y + submenuBox.height).toBeLessThanOrEqual(viewportHeight);
+
+    // the last item must actually be reachable via the sub-menu's own
+    // internal scroll container
+    await submenu.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+
+    const lastItem = page.locator('span:text-is("Sub item 40")');
+    await expect(lastItem).toBeInViewport();
+    await expectAlert(
+      page,
+      () => lastItem.click(),
+      'clicked: sub-key40'
+    );
+  });
+});

--- a/test/unit/direction-rtl.test.js
+++ b/test/unit/direction-rtl.test.js
@@ -1,0 +1,138 @@
+// Karma's test page only loads the plugin's JS (see karma.conf.js), not its
+// compiled CSS, so `.context-menu-list` never gets `position: absolute` from
+// jquery.contextMenu.scss. Without that, the inline top/left the plugin sets
+// via JS have no visual effect (a statically positioned element ignores
+// top/left), which would make the positioning assertions below meaningless.
+// Add just enough CSS ourselves to make position math observable.
+$('<style>.context-menu-list { position: absolute; }</style>').appendTo('head');
+
+QUnit.module('direction (rtl support)', {
+  afterEach: function() {
+    $.contextMenu('destroy');
+    var $fixture = $('#qunit-fixture');
+    if ($fixture.length) {
+      $fixture.html('');
+    }
+  }
+});
+
+function ensureFixture() {
+  var $fixture = $('#qunit-fixture');
+  if ($fixture.length === 0) {
+    $('<div id="qunit-fixture">').appendTo('body');
+    $fixture = $('#qunit-fixture');
+  }
+  return $fixture;
+}
+
+QUnit.test('default (ltr) menu does not get the context-menu-rtl class', function(assert) {
+  var $fixture = ensureFixture();
+  $fixture.append('<span class="context-menu-ltr-default">right click me</span>');
+
+  $.contextMenu({
+    selector: '.context-menu-ltr-default',
+    items: {
+      copy: {name: 'Copy'}
+    }
+  });
+
+  $('.context-menu-ltr-default').contextMenu();
+
+  var $menu = $('.context-menu-ltr-default').data('contextMenu').$menu;
+  assert.notOk($menu.hasClass('context-menu-rtl'), 'root menu should not have the rtl class by default');
+});
+
+QUnit.test('direction: "rtl" adds the context-menu-rtl class to the root menu and to sub-menus', function(assert) {
+  var $fixture = ensureFixture();
+  $fixture.append('<span class="context-menu-rtl-trigger">right click me</span>');
+
+  $.contextMenu({
+    selector: '.context-menu-rtl-trigger',
+    direction: 'rtl',
+    items: {
+      copy: {name: 'Copy'},
+      more: {
+        name: 'More',
+        items: {
+          sub1: {name: 'Sub item'}
+        }
+      }
+    }
+  });
+
+  $('.context-menu-rtl-trigger').contextMenu();
+
+  var $rootMenu = $('.context-menu-rtl-trigger').data('contextMenu').$menu;
+  assert.ok($rootMenu.hasClass('context-menu-rtl'), 'root menu should have the context-menu-rtl class');
+
+  var $subMenu = $rootMenu.find('.context-menu-submenu').first().children('.context-menu-list');
+  assert.equal($subMenu.length, 1, 'sanity check: sub-menu was found');
+  assert.ok($subMenu.hasClass('context-menu-rtl'), 'sub-menu should also have the context-menu-rtl class');
+});
+
+QUnit.test('direction: "rtl" opens sub-menus to the left of their parent item instead of the right', function(assert) {
+  // Show the root menu at an explicit, comfortably-inset position (well away
+  // from the viewport edges) so the jQuery UI position "flipfit" collision
+  // handling doesn't override the intended open side just because one side
+  // happens to be short on space - that would defeat the point of this
+  // assertion.
+  var $fixtureLtr = ensureFixture();
+  $fixtureLtr.append('<span class="context-menu-ltr-sub">right click me (ltr)</span>');
+
+  $.contextMenu({
+    selector: '.context-menu-ltr-sub',
+    items: {
+      more: {
+        name: 'More',
+        items: {
+          sub1: {name: 'Sub item'}
+        }
+      }
+    }
+  });
+
+  $('.context-menu-ltr-sub').contextMenu({x: 300, y: 100});
+  var $ltrItem = $('.context-menu-ltr-sub').data('contextMenu').$menu.find('.context-menu-submenu').first();
+  $ltrItem.trigger('contextmenu:focus');
+
+  var $ltrSubMenu = $ltrItem.children('.context-menu-list');
+  var ltrItemOffset = $ltrItem.offset().left;
+  var ltrSubMenuOffset = $ltrSubMenu.offset().left;
+
+  assert.ok(
+    ltrSubMenuOffset >= ltrItemOffset,
+    'ltr: sub-menu should open at/after the parent item\'s left edge (opens to the right). item=' + ltrItemOffset + ' sub=' + ltrSubMenuOffset
+  );
+
+  $.contextMenu('destroy');
+  $fixtureLtr.html('');
+
+  var $fixtureRtl = ensureFixture();
+  $fixtureRtl.append('<span class="context-menu-rtl-sub">right click me (rtl)</span>');
+
+  $.contextMenu({
+    selector: '.context-menu-rtl-sub',
+    direction: 'rtl',
+    items: {
+      more: {
+        name: 'More',
+        items: {
+          sub1: {name: 'Sub item'}
+        }
+      }
+    }
+  });
+
+  $('.context-menu-rtl-sub').contextMenu({x: 300, y: 100});
+  var $rtlItem = $('.context-menu-rtl-sub').data('contextMenu').$menu.find('.context-menu-submenu').first();
+  $rtlItem.trigger('contextmenu:focus');
+
+  var $rtlSubMenu = $rtlItem.children('.context-menu-list');
+  var rtlItemOffset = $rtlItem.offset().left;
+  var rtlSubMenuOffset = $rtlSubMenu.offset().left;
+
+  assert.ok(
+    rtlSubMenuOffset <= rtlItemOffset,
+    'rtl: sub-menu should open before the parent item\'s left edge (opens to the left). item=' + rtlItemOffset + ' sub=' + rtlSubMenuOffset
+  );
+});


### PR DESCRIPTION
Closes #742

## Summary

Adds a `direction` option to `$.contextMenu({...})` (default `'ltr'`). When set to `'rtl'`:

- A `context-menu-rtl` class is added to the root menu **and** every sub-menu (including detached sub-menus that get moved to `<body>` when their parent menu is scrollable, see #775, so they don't lose the styling when they're no longer a DOM descendant of the root).
- CSS mirrors: text alignment (`direction: rtl; text-align: right`), icon placement (icon moves to the right edge instead of the left, covering both the icon-font and FontAwesome-5 code paths), checkbox/radio spacing, and the submenu-arrow triangle (now points left and sits on the left edge instead of the right).
- The submenu positioning logic (`positionSubmenu` in `src/jquery.contextMenu.js`) flips the jQuery UI `.position()` `my`/`at` arguments (and the equivalent fallback/detached-submenu math) so sub-menus open to the *left* of their parent item instead of the right, with the same `flipfit`/edge-clamping behavior as the existing LTR code so it still flips back to the right if there isn't enough room on the left.

## Scope notes

This covers the two things asked for in #742 (menu item text direction/alignment, and RTL support in general): a CSS hook for styling and a real flip of which side sub-menus open on. Root-menu placement itself already has viewport collision handling (`fit`) that isn't direction-specific, so it needed no changes.

## Files changed

- `src/jquery.contextMenu.js` – new `direction` default option, class applied at menu-creation time, `positionSubmenu` flip for both the jQuery UI code path and the plain-JS/detached-submenu fallback paths.
- `src/sass/jquery.contextMenu.scss` – `.context-menu-rtl` rules mirroring text alignment, icon placement, submenu arrow and initial submenu position.
- `documentation/docs.md` – documents the new `direction` option with an example.
- `test/unit/direction-rtl.test.js` – new QUnit regression tests: default menu has no rtl class, `direction: 'rtl'` adds the class to both the root menu and its sub-menus, and a sub-menu opens to the left of its parent item in `rtl` mode vs. to the right in the default `ltr` mode.

## Test plan

- [x] `npm run test-unit` (karma + qunit, ChromeHeadless) – 34/34 passing, including the 3 new RTL tests.
- [x] `npm run test:fixtures && npx playwright test` – 15/15 passing, no regressions.
- [x] Compiled the SCSS standalone (`npx sass`) to confirm it has no syntax errors.

`dist/` was intentionally left untouched per this repo's convention of rebuilding it at publish time.