### PR TITLE
fix: cap and scroll a sub-menu that's taller than the viewport

### DIFF
--- a/documentation/demo/long-submenu-short-root.md
+++ b/documentation/demo/long-submenu-short-root.md
@@ -1,0 +1,53 @@
+---
+currentMenu: long-submenu-short-root
+---
+
+# Demo: Short menu with a long sub-menu (overflow)
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [Example code](#example-code)
+- [Example HTML](#example-html)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<span class="context-menu-one btn btn-neutral">right click me</span>
+
+## Example code
+
+<script type="text/javascript" class="showcase">
+$(function(){
+    /**************************************************
+     * Context-Menu that itself fits the viewport, but
+     * whose sub-menu has many items (taller than the
+     * viewport) - reproduces #752, a variant of the
+     * overflow clipping issue (#775) where it's the
+     * sub-menu, not the root menu, that overflows.
+     **************************************************/
+    var subItems = {};
+    for (var i = 1; i <= 40; i++) {
+        subItems['sub-key' + i] = {name: 'Sub item ' + i};
+    }
+
+    $.contextMenu({
+        selector: '.context-menu-one',
+        callback: function(key, options) {
+            var m = "clicked: " + key;
+            window.console && console.log(m) || alert(m);
+        },
+        items: {
+            item1: {name: 'Item 1'},
+            item2: {name: 'Item 2'},
+            fold1: {
+                name: 'Long sub group',
+                items: subItems
+            }
+        }
+    });
+});
+</script>
+
+## Example HTML
+<div style="display:none;" class="showcase" data-showcase-import=".context-menu-one"></div>

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -242,18 +242,85 @@
                     // call positionSubmenu after promise is completed.
                     return;
                 }
+
+                // 'top' (used further down to position a detached sub-menu)
+                // places the element's margin edge, not its border edge, so
+                // its own margin-top still pushes the visible box down from
+                // wherever 'top' is clamped to - both when capping the
+                // height below and when clamping 'top' to the bottom of the
+                // viewport, or the box's actual bottom edge overshoots by
+                // that margin either way.
+                var marginTop = parseFloat($menu.css('margin-top')) || 0;
+
+                // A sub-menu taller than the viewport can't be fully reached in
+                // its normal position: items past the bottom edge of the screen
+                // have no scrollbar and no room to flip into, since the
+                // sub-menu's top is already clamped to the item it hangs off
+                // of (below, and in the detached branch further down). Detach
+                // it to <body> - the same mechanism used for #775, when the
+                // ROOT menu overflows - if it isn't already, and cap/scroll it
+                // exactly like an overflowing root menu (see op.activated),
+                // regardless of whether an ancestor menu needed that same
+                // treatment. (#752)
+                //
+                // This sizing/detaching check only runs while the sub-menu
+                // isn't detached yet. handle.focusItem() calls positionSubmenu()
+                // again for every sibling item hovered inside an
+                // already-open sub-menu (they all share the same opener/menu
+                // pair), so re-measuring and re-capping on every one of those
+                // calls would reset the scroll position of a sub-menu the
+                // user has already scrolled through. Once detached, sizing is
+                // considered settled for the rest of this show cycle; it's
+                // only redone in op.reattachSubmenus(), right before the next
+                // time the root menu is (re)activated.
+                if (!$menu.hasClass('context-menu-detached') && ($menu.outerHeight() || $menu.height()) > $win.height()) {
+                    var root = this.data('contextMenuRoot');
+                    if (root) {
+                        root._detachedSubmenus = root._detachedSubmenus || [];
+                        $menu
+                            .addClass('context-menu-detached')
+                            .data('contextMenuDetachedFrom', this)
+                            .appendTo(document.body);
+                        root._detachedSubmenus.push($menu);
+                        // This runs after handle.focusItem() already decided
+                        // (based on the pre-detach state) whether to add the
+                        // detached-visibility class, so it never saw this
+                        // sub-menu as detached. Add it here instead - without
+                        // it, moving the sub-menu to <body> just above drops it
+                        // out from under the CSS parent/child selector that was
+                        // making it visible, and it disappears immediately.
+                        if (this.hasClass(root.classNames.hover)) {
+                            $menu.addClass(root.classNames.visible);
+                            $menu.data('_scrollTopAtShow', root.$menu.scrollTop());
+                        }
+                        $menu.css({
+                            // see the note on the equivalent root-menu cap in
+                            // op.activated for why overflow-x must be
+                            // 'hidden' rather than 'visible' here
+                            'overflow-x': 'hidden',
+                            'overflow-y': 'auto'
+                        // .outerHeight(value), rather than .css('height',
+                        // value), accounts for border/padding so the
+                        // element's actual (outer) height ends up matching
+                        // the target exactly
+                        }).outerHeight($win.height() - marginTop);
+                    }
+                }
+
                 if ($menu.hasClass('context-menu-detached')) {
-                    // This sub-menu was moved out to <body> (see op.detachSubmenus)
-                    // because its parent menu is scrollable and would otherwise
-                    // clip it. Position it like a root menu would be positioned:
-                    // in page coordinates, next to the trigger item, flipped and
-                    // clamped to stay within the viewport.
+                    // This sub-menu was moved out to <body> (see op.detachSubmenus,
+                    // or the on-demand detach above) because its parent menu is
+                    // scrollable, or the sub-menu is simply taller than the
+                    // viewport itself, and would otherwise clip it. Position it
+                    // like a root menu would be positioned: in page coordinates,
+                    // next to the trigger item, flipped and clamped to stay
+                    // within the viewport.
                     var itemOffset = this.offset(),
                         menuWidth = $menu.outerWidth() || $menu.width(),
                         menuHeight = $menu.outerHeight() || $menu.height(),
                         left = itemOffset.left + this.outerWidth() - 5,
                         top = itemOffset.top - 9,
-                        maxTop = $win.scrollTop() + $win.height() - menuHeight;
+                        maxTop = $win.scrollTop() + $win.height() - menuHeight - marginTop;
 
                     if (left + menuWidth > $win.scrollLeft() + $win.width()) {
                         // doesn't fit to the right of the item, flip to the left
@@ -1684,7 +1751,13 @@
                     $sub
                         .removeClass('context-menu-detached ' + root.classNames.visible)
                         .removeData('contextMenuDetachedFrom')
-                        .css({top: '', left: ''});
+                        // undo any height cap applied in positionSubmenu() for
+                        // a sub-menu that was taller than the viewport (see
+                        // #752), so it's re-measured at its natural height
+                        // the next time it's shown, rather than keeping
+                        // whatever cap happened to be in place last time
+                        // (e.g. from a viewport that's since grown taller).
+                        .css({top: '', left: '', height: '', 'overflow-x': '', 'overflow-y': ''});
                     if ($originalParent && $originalParent.length) {
                         $sub.appendTo($originalParent);
                     }

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -273,7 +273,7 @@
                 // considered settled for the rest of this show cycle; it's
                 // only redone in op.reattachSubmenus(), right before the next
                 // time the root menu is (re)activated.
-                if (!$menu.hasClass('context-menu-detached') && ($menu.outerHeight() || $menu.height()) > $win.height()) {
+                if (!$menu.hasClass('context-menu-detached') && (preciseOuterHeight($menu) || $menu.height()) > $win.height()) {
                     var root = this.data('contextMenuRoot');
                     if (root) {
                         root._detachedSubmenus = root._detachedSubmenus || [];
@@ -317,7 +317,9 @@
                     // within the viewport.
                     var itemOffset = this.offset(),
                         menuWidth = $menu.outerWidth() || $menu.width(),
-                        menuHeight = $menu.outerHeight() || $menu.height(),
+                        // see preciseOuterHeight() for why this can't just be
+                        // $menu.outerHeight()
+                        menuHeight = preciseOuterHeight($menu) || $menu.height(),
                         left = itemOffset.left + this.outerWidth() - 5,
                         top = itemOffset.top - 9,
                         maxTop = $win.scrollTop() + $win.height() - menuHeight - marginTop;
@@ -396,6 +398,19 @@
                 }
             }
             return zin;
+        },
+        // Precise (fractional) border-box height of an element, used instead
+        // of jQuery's own outerHeight() getter for viewport-overflow math
+        // (see positionSubmenu()) where sub-pixel accuracy actually matters:
+        // outerHeight() (no argument) is fractional (getBoundingClientRect-
+        // based) as of jQuery 3, but is ROUNDED to a whole pixel in jQuery
+        // <3. Mixing that rounded value into a clamp computed against other,
+        // still-fractional measurements (like $win.height() or margin-top)
+        // silently let the sub-menu's real, unrounded box overshoot the
+        // viewport by up to ~1px on jQuery 1.x/2.x - only ever surfaced on
+        // those older jQuery versions.
+        preciseOuterHeight = function ($el) {
+            return $el && $el.length ? $el[0].getBoundingClientRect().height : 0;
         },
         // event handlers
         handle = {

--- a/test/specs/overflow-submenu-only.js
+++ b/test/specs/overflow-submenu-only.js
@@ -1,0 +1,81 @@
+const { test, expect } = require('@playwright/test');
+const { fixture, expectAlert } = require('../support/helpers');
+
+// Regression test for https://github.com/swisnl/jQuery-contextMenu/issues/752
+// Unlike #775 (a root menu taller than the viewport clipping its sub-menus),
+// here the ROOT menu is short and fits the viewport just fine, but the
+// SUB-MENU itself has enough items to be taller than the viewport. Nothing
+// caps its height or makes it scrollable, so items past the bottom edge of
+// the viewport are unreachable - there's no scrollbar and no way to get to
+// them with the mouse.
+test.describe('Test overflow / scrollable sub-menu whose root menu fits the viewport (#752)', () => {
+  test.use({ viewport: { width: 1000, height: 500 } });
+
+  test('long sub-menu of a short root menu is capped to the viewport and scrollable', async ({ page }) => {
+    await page.goto(fixture('long-submenu-short-root.html'));
+    await page.click('.context-menu-one', { button: 'right' });
+
+    const menu = page.locator('.context-menu-root');
+    await expect(menu).toBeVisible();
+    // sanity check: the root menu itself fits comfortably and is NOT
+    // scrollable - this test is about the sub-menu overflowing, not the root
+    await expect(menu).not.toHaveCSS('overflow-y', 'auto');
+
+    await page.hover('span:text-is("Long sub group")');
+
+    const submenu = page.locator('.context-menu-list:not(.context-menu-root)');
+    await expect(submenu).toBeVisible();
+
+    const viewportHeight = page.viewportSize().height;
+    const submenuBox = await submenu.boundingBox();
+
+    // the sub-menu must not extend past the bottom of the viewport - if it
+    // does, it needs to be capped in height and made scrollable instead
+    expect(submenuBox.y + submenuBox.height).toBeLessThanOrEqual(viewportHeight);
+
+    // the last item must actually be reachable: scroll the sub-menu's own
+    // internal overflow container (rather than the page) all the way down,
+    // then click the now fully-in-view last item
+    await submenu.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+
+    const lastItem = page.locator('span:text-is("Sub item 40")');
+    await expect(lastItem).toBeInViewport();
+    await expectAlert(
+      page,
+      () => lastItem.click(),
+      'clicked: sub-key40'
+    );
+  });
+
+  // Regression test for a bug caught while fixing #752: handle.focusItem()
+  // calls positionSubmenu() again for every sibling item hovered inside an
+  // already-open sub-menu (they all share the same opener/menu pair, see
+  // op.create). An earlier version of the #752 fix re-measured and
+  // re-capped the sub-menu's height/overflow on every single one of those
+  // calls, which reset its scrollTop back to 0 each time - so simply
+  // hovering another item after scrolling silently snapped the sub-menu
+  // back to the top.
+  test('hovering a sibling item does not reset an already-scrolled sub-menu', async ({ page }) => {
+    await page.goto(fixture('long-submenu-short-root.html'));
+    await page.click('.context-menu-one', { button: 'right' });
+    await page.hover('span:text-is("Long sub group")');
+
+    const submenu = page.locator('.context-menu-list:not(.context-menu-root)');
+    await expect(submenu).toBeVisible();
+
+    await submenu.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+    const scrollTopAfterScroll = await submenu.evaluate((el) => el.scrollTop);
+    expect(scrollTopAfterScroll).toBeGreaterThan(0);
+
+    // hover a plain sibling item within the same (already scrolled)
+    // sub-menu - this re-triggers positionSubmenu() on the sub-menu
+    await page.hover('span:text-is("Sub item 40")');
+
+    const scrollTopAfterHover = await submenu.evaluate((el) => el.scrollTop);
+    expect(scrollTopAfterHover).toBe(scrollTopAfterScroll);
+  });
+});


### PR DESCRIPTION
Closes #752

## Problem

#775 (merged in PR #787) fixed the case where the ROOT menu is taller than the viewport: it caps the root's height, makes it scrollable, and detaches its direct sub-menus to `<body>` so they aren't clipped by that scroll container.

It did not handle the reverse case, which is what #752 actually reports: a short root menu whose SUB-MENU has enough items to be taller than the viewport on its own. Nothing capped or scrolled that sub-menu, so items past the bottom edge of the screen were simply unreachable, no scrollbar, no room to flip.

## Fix

`positionSubmenu()` now detects when a sub-menu it's about to show is itself taller than the viewport. If so, it detaches the sub-menu to `<body>` (the same mechanism #775 already uses) and caps/scrolls it exactly like an overflowing root menu is handled in `op.activated()`, regardless of whether the root needed that treatment.

This sizing check only runs once per "show" of the sub-menu. `handle.focusItem()` calls `positionSubmenu()` again for every sibling item hovered inside an already-open sub-menu (they share the same opener/menu pair), so re-measuring and re-capping on every one of those calls would otherwise reset the sub-menu's scroll position back to zero mid-interaction - caught this while writing the regression test and fixed it by only doing the sizing work while the sub-menu isn't marked `context-menu-detached` yet; `op.reattachSubmenus()` clears the cap again before the next full reopen.

## Testing

- Added `test/specs/overflow-submenu-only.js` (Playwright): reproduces #752 with a short root menu + a 40-item sub-menu at a 1000x500 viewport, asserts the sub-menu stays within the viewport, is scrollable, and its last item is reachable/clickable. Also has a dedicated regression test for the scroll-reset bug described above.
- Added `documentation/demo/long-submenu-short-root.md` fixture used by the test.
- `npm run test:fixtures && npx playwright test` - all 17 tests pass (16 existing + 1 new suite with 2 tests), including the existing `overflow-submenu.js` (#775) suite, unaffected.
- `npm run test-unit` (karma/qunit) - all 31 tests pass.
- `npx eslint` - clean.

No changes to `dist/` (rebuilt at publish time per project convention).