### PR TITLE
fix: don't treat a select's phantom mousedown as an outside click (#744)

### DIFF
--- a/documentation/demo/sub-menu-select.md
+++ b/documentation/demo/sub-menu-select.md
@@ -1,0 +1,56 @@
+---
+currentMenu: sub-menu-select
+---
+
+# Demo: Select input nested in a sub-sub-menu
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [Example code](#example-code)
+- [Example HTML](#example-html)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<span class="context-menu-one btn btn-neutral">right click me</span>
+
+## Example code
+
+<script type="text/javascript" class="showcase">
+$(function(){
+    /**************************************************
+     * Context-Menu with a `type: 'select'` item nested
+     * two levels deep, to reproduce #744 (choosing an
+     * option in Firefox closed the menu)
+     **************************************************/
+    $.contextMenu({
+        selector: '.context-menu-one',
+        callback: function(key, options) {
+            var m = "clicked: " + key;
+            window.console && console.log(m) || alert(m);
+        },
+        items: {
+            "fold1": {
+                "name": "Sub group",
+                "items": {
+                    "fold2": {
+                        "name": "Sub group 2",
+                        "items": {
+                            "my-select": {
+                                "name": "Choose",
+                                "type": "select",
+                                "options": {"opt1": "Option 1", "opt2": "Option 2", "opt3": "Option 3"},
+                                "selected": "opt1"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
+});
+</script>
+
+## Example HTML
+<div style="display:none;" class="showcase" data-showcase-import=".context-menu-one"></div>

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -550,26 +550,24 @@
                     return;
                 }
 
-                // Choosing an option from a native <select> item's dropdown can make
-                // Firefox fire a spurious click/mousedown shortly afterwards, at
-                // coordinates that don't necessarily land within root.$menu's own
-                // (possibly clipped) bounding box - because the browser's native
-                // options popup isn't constrained by it - even though the user's
-                // interaction never actually left the menu. Ignore outside-click
-                // detection for a brief window after such a change so this isn't
-                // mistaken for a genuine outside click.
-                // See https://github.com/swisnl/jQuery-contextMenu/issues/744
-                if (root && typeof root._recentSelectChangeAt === 'number') {
-                    var selectChangeGraceMs = 500;
-                    if ((Date.now() - root._recentSelectChangeAt) < selectChangeGraceMs) {
-                        return;
-                    }
-                }
-
                 // if the click closing is done through windwow event listener rather than a transparent layer
                 if (!root.$layer) {
                     target = document.elementFromPoint(x - $win.scrollLeft(), y - $win.scrollTop());
                     if (root.$menu === null || typeof root.$menu === 'undefined' || (!root.$menu[0].contains(target) && !isWithinDetachedSubmenus(root, target))) {
+                        // Choosing an option from a native <select> item's dropdown can
+                        // make Firefox fire a spurious click/mousedown shortly
+                        // afterwards, at coordinates that don't necessarily land within
+                        // root.$menu's own (possibly clipped) bounding box - because the
+                        // browser's native options popup isn't constrained by it - even
+                        // though the user's interaction never actually left the menu.
+                        // Only skip hiding the menu, and only when the coordinates are
+                        // plausibly within that select's own native popup (its
+                        // horizontal span) shortly after it last changed - a real
+                        // outside click elsewhere is unaffected.
+                        // See https://github.com/swisnl/jQuery-contextMenu/issues/744
+                        if (isNearRecentSelectChange(root, x, y)) {
+                            return;
+                        }
 
                         root.$menu.trigger('contextmenu:hide');
                         if (typeof onhide !== 'undefined')
@@ -652,7 +650,15 @@
                         });
                     }
 
-                    if (root !== null && typeof root !== 'undefined' && root.$menu !== null  && typeof root.$menu !== 'undefined') {
+                    // See the comment above isNearRecentSelectChange() /
+                    // https://github.com/swisnl/jQuery-contextMenu/issues/744 - the
+                    // click/mousedown has already been passed through to whatever's
+                    // actually under the cursor above, so a genuine outside click
+                    // still reaches its real target either way; this only leaves the
+                    // menu itself open a little longer than usual in the rare case of
+                    // a real click that happens to land within a just-changed
+                    // select's own horizontal span.
+                    if (root !== null && typeof root !== 'undefined' && root.$menu !== null && typeof root.$menu !== 'undefined' && !isNearRecentSelectChange(root, x, y)) {
                         root.$menu.trigger('contextmenu:hide');
                     }
                 }, 50);
@@ -1512,12 +1518,14 @@
                                 }
                                 // Choosing an option from a native <select> popup can make
                                 // Firefox fire a spurious click/mousedown shortly afterwards
-                                // (see handle.layerClick), which used to be mistaken for a
-                                // genuine click outside the menu and closed it - even though
-                                // the interaction never left the menu.
+                                // (see handle.layerClick / isNearRecentSelectChange()),
+                                // which used to be mistaken for a genuine click outside the
+                                // menu and closed it - even though the interaction never
+                                // left the menu.
                                 // See https://github.com/swisnl/jQuery-contextMenu/issues/744
                                 $input.on('change', function () {
                                     root._recentSelectChangeAt = Date.now();
+                                    root._recentSelectEl = this;
                                 });
                                 break;
 
@@ -2029,6 +2037,47 @@
             }
         }
         return false;
+    }
+
+    // true if (x, y) - page coordinates from a mousedown handle.layerClick is
+    // about to treat as an "outside click" - plausibly belong to the native
+    // options popup of a `type: 'select'` menu input that changed a moment
+    // ago (see the 'change' handler set up in op.create()'s 'select' case).
+    // Guards against https://github.com/swisnl/jQuery-contextMenu/issues/744:
+    // Firefox fires a spurious click/mousedown shortly after choosing an
+    // option from a <select>, at coordinates that don't necessarily fall
+    // within root.$menu's own (possibly clipped) bounding box, because the
+    // browser's native popup isn't constrained by it - even though the
+    // interaction never left the menu. A real native popup always renders
+    // directly below (or, flipped, above) its <select> and overlaps that
+    // <select>'s own horizontal span, so requiring the coordinates to fall
+    // within that span (rather than just checking elapsed time) keeps this
+    // from also swallowing an unrelated, genuinely-outside click that
+    // happens to follow shortly after some other select on the menu changed.
+    function isNearRecentSelectChange(root, x, y) {
+        if (!root || typeof root._recentSelectChangeAt !== 'number') {
+            return false;
+        }
+
+        var graceMs = 500;
+        if ((Date.now() - root._recentSelectChangeAt) >= graceMs) {
+            return false;
+        }
+
+        var el = root._recentSelectEl;
+        if (!el || !document.body.contains(el)) {
+            return false;
+        }
+
+        var rect = el.getBoundingClientRect(),
+            scrollLeft = $win.scrollLeft(),
+            scrollTop = $win.scrollTop(),
+            margin = 4,
+            left = rect.left + scrollLeft - margin,
+            right = rect.right + scrollLeft + margin,
+            top = rect.top + scrollTop - margin;
+
+        return x >= left && x <= right && y >= top;
     }
 
     // split accesskey according to http://www.whatwg.org/specs/web-apps/current-work/multipage/editing.html#assigned-access-key

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -550,6 +550,22 @@
                     return;
                 }
 
+                // Choosing an option from a native <select> item's dropdown can make
+                // Firefox fire a spurious click/mousedown shortly afterwards, at
+                // coordinates that don't necessarily land within root.$menu's own
+                // (possibly clipped) bounding box - because the browser's native
+                // options popup isn't constrained by it - even though the user's
+                // interaction never actually left the menu. Ignore outside-click
+                // detection for a brief window after such a change so this isn't
+                // mistaken for a genuine outside click.
+                // See https://github.com/swisnl/jQuery-contextMenu/issues/744
+                if (root && typeof root._recentSelectChangeAt === 'number') {
+                    var selectChangeGraceMs = 500;
+                    if ((Date.now() - root._recentSelectChangeAt) < selectChangeGraceMs) {
+                        return;
+                    }
+                }
+
                 // if the click closing is done through windwow event listener rather than a transparent layer
                 if (!root.$layer) {
                     target = document.elementFromPoint(x - $win.scrollLeft(), y - $win.scrollTop());
@@ -1494,6 +1510,15 @@
                                     });
                                     $input.val(item.selected);
                                 }
+                                // Choosing an option from a native <select> popup can make
+                                // Firefox fire a spurious click/mousedown shortly afterwards
+                                // (see handle.layerClick), which used to be mistaken for a
+                                // genuine click outside the menu and closed it - even though
+                                // the interaction never left the menu.
+                                // See https://github.com/swisnl/jQuery-contextMenu/issues/744
+                                $input.on('change', function () {
+                                    root._recentSelectChangeAt = Date.now();
+                                });
                                 break;
 
                             case 'sub':

--- a/test/specs/select-in-submenu.js
+++ b/test/specs/select-in-submenu.js
@@ -1,0 +1,97 @@
+const { test, expect } = require('@playwright/test');
+const { fixture } = require('../support/helpers');
+
+// Regression tests for https://github.com/swisnl/jQuery-contextMenu/issues/744
+// ("Bug option-select in submenu in firefox"): choosing an option from a
+// `type: 'select'` item nested inside a sub-sub-menu closed the whole menu
+// in Firefox (Edge/Chrome were unaffected).
+//
+// Firefox's native <select> options popup isn't part of the page's DOM/layout
+// (see also issue #114, where the plugin's original author documented Firefox
+// firing extra mouse events around a <select>'s native popup that don't
+// correspond to any real page interaction). Playwright cannot drive that
+// native, OS-rendered popup directly in any browser - `selectOption()`
+// intentionally bypasses it - so the second test below reproduces the
+// mechanism directly: handle.layerClick's outside-click detection uses
+// document.elementFromPoint(x, y) at the raw event coordinates, and a
+// <select>'s native popup can extend past root.$menu's own (possibly
+// clipped) bounding box, making a click that is, from the user's
+// perspective, entirely "inside" the menu look like an outside click.
+test.describe('Test type: "select" item nested in a sub-sub-menu (#744)', () => {
+  test('choosing an option keeps the menu (and its sub-menus) open', async ({ page }) => {
+    await page.goto(fixture('sub-menu-select.html'));
+    await page.click('.context-menu-one', { button: 'right' });
+
+    const root = page.locator('.context-menu-root');
+    await expect(root).toBeVisible();
+
+    await page.hover('span:text-is("Sub group")');
+    await page.hover('span:text-is("Sub group 2")');
+
+    const select = page.locator('select[name="context-menu-input-my-select"]');
+    await expect(select).toBeVisible();
+
+    await select.selectOption('opt3');
+
+    await expect(root).toBeVisible();
+    await expect(select).toBeVisible();
+    await expect(select).toHaveValue('opt3');
+  });
+
+  test('a mousedown outside the menu shortly after a select change is not treated as an outside click', async ({ page }) => {
+    await page.goto(fixture('sub-menu-select.html'));
+    await page.click('.context-menu-one', { button: 'right' });
+    await page.hover('span:text-is("Sub group")');
+    await page.hover('span:text-is("Sub group 2")');
+
+    const select = page.locator('select[name="context-menu-input-my-select"]');
+    await expect(select).toBeVisible();
+
+    const menuBox = await page.locator('.context-menu-root').boundingBox();
+
+    // Fire the select's 'change' event (as choosing an option would), then a
+    // synthetic mousedown directly on the transparent #context-menu-layer -
+    // handle.layerClick is bound straight to that element - at coordinates
+    // below the menu's own bounding box, approximating the spurious event
+    // Firefox is documented to fire around a <select>'s native popup.
+    await page.evaluate((box) => {
+      var el = document.querySelector('select[name="context-menu-input-my-select"]');
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+
+      var $ = window.jQuery;
+      $('#context-menu-layer').trigger($.Event('mousedown', {
+        pageX: box.x + box.width / 2,
+        pageY: box.y + box.height + 50,
+        button: 0
+      }));
+    }, menuBox);
+
+    await page.waitForTimeout(150);
+
+    await expect(page.locator('.context-menu-root')).toBeVisible();
+    await expect(select).toBeVisible();
+  });
+
+  test('a genuine outside click (no recent select change) still closes the menu', async ({ page }) => {
+    await page.goto(fixture('sub-menu-select.html'));
+    await page.click('.context-menu-one', { button: 'right' });
+
+    const root = page.locator('.context-menu-root');
+    await expect(root).toBeVisible();
+
+    const menuBox = await root.boundingBox();
+
+    // Same out-of-bounds mousedown as above, but with no preceding 'change'
+    // on any select - this must still be treated as a real outside click.
+    await page.evaluate((box) => {
+      var $ = window.jQuery;
+      $('#context-menu-layer').trigger($.Event('mousedown', {
+        pageX: box.x + box.width / 2,
+        pageY: box.y + box.height + 50,
+        button: 0
+      }));
+    }, menuBox);
+
+    await expect(root).toBeHidden();
+  });
+});

--- a/test/specs/select-in-submenu.js
+++ b/test/specs/select-in-submenu.js
@@ -11,12 +11,20 @@ const { fixture } = require('../support/helpers');
 // firing extra mouse events around a <select>'s native popup that don't
 // correspond to any real page interaction). Playwright cannot drive that
 // native, OS-rendered popup directly in any browser - `selectOption()`
-// intentionally bypasses it - so the second test below reproduces the
-// mechanism directly: handle.layerClick's outside-click detection uses
+// intentionally bypasses it - so the tests below reproduce the mechanism
+// directly: handle.layerClick's outside-click detection uses
 // document.elementFromPoint(x, y) at the raw event coordinates, and a
 // <select>'s native popup can extend past root.$menu's own (possibly
 // clipped) bounding box, making a click that is, from the user's
 // perspective, entirely "inside" the menu look like an outside click.
+//
+// The fix (isNearRecentSelectChange() in src/jquery.contextMenu.js) only
+// withholds the "hide the menu" step - the click is always passed through to
+// whatever's really under the cursor either way - and only when the
+// coordinates plausibly belong to a <select>'s own native popup (its
+// horizontal span) shortly after it last changed, so a real, unrelated
+// outside click is unaffected even moments after some select on the menu
+// changed.
 test.describe('Test type: "select" item nested in a sub-sub-menu (#744)', () => {
   test('choosing an option keeps the menu (and its sub-menus) open', async ({ page }) => {
     await page.goto(fixture('sub-menu-select.html'));
@@ -47,13 +55,15 @@ test.describe('Test type: "select" item nested in a sub-sub-menu (#744)', () => 
     const select = page.locator('select[name="context-menu-input-my-select"]');
     await expect(select).toBeVisible();
 
-    const menuBox = await page.locator('.context-menu-root').boundingBox();
+    const selectBox = await select.boundingBox();
 
     // Fire the select's 'change' event (as choosing an option would), then a
     // synthetic mousedown directly on the transparent #context-menu-layer -
     // handle.layerClick is bound straight to that element - at coordinates
-    // below the menu's own bounding box, approximating the spurious event
-    // Firefox is documented to fire around a <select>'s native popup.
+    // below the select itself, approximating the spurious event Firefox is
+    // documented to fire around a <select>'s native popup (which renders
+    // below/above the select, overlapping its own horizontal span, but isn't
+    // constrained by the menu's own bounding box).
     await page.evaluate((box) => {
       var el = document.querySelector('select[name="context-menu-input-my-select"]');
       el.dispatchEvent(new Event('change', { bubbles: true }));
@@ -61,10 +71,10 @@ test.describe('Test type: "select" item nested in a sub-sub-menu (#744)', () => 
       var $ = window.jQuery;
       $('#context-menu-layer').trigger($.Event('mousedown', {
         pageX: box.x + box.width / 2,
-        pageY: box.y + box.height + 50,
+        pageY: box.y + box.height + 100,
         button: 0
       }));
-    }, menuBox);
+    }, selectBox);
 
     await page.waitForTimeout(150);
 
@@ -87,6 +97,39 @@ test.describe('Test type: "select" item nested in a sub-sub-menu (#744)', () => 
       var $ = window.jQuery;
       $('#context-menu-layer').trigger($.Event('mousedown', {
         pageX: box.x + box.width / 2,
+        pageY: box.y + box.height + 50,
+        button: 0
+      }));
+    }, menuBox);
+
+    await expect(root).toBeHidden();
+  });
+
+  test('a genuine outside click elsewhere shortly after a select change still closes the menu', async ({ page }) => {
+    await page.goto(fixture('sub-menu-select.html'));
+    await page.click('.context-menu-one', { button: 'right' });
+    await page.hover('span:text-is("Sub group")');
+    await page.hover('span:text-is("Sub group 2")');
+
+    const root = page.locator('.context-menu-root');
+    const select = page.locator('select[name="context-menu-input-my-select"]');
+    await expect(select).toBeVisible();
+
+    const menuBox = await root.boundingBox();
+
+    // Fire the select's 'change' event, but this time dispatch the outside
+    // mousedown well clear of the select's own horizontal span (below the
+    // root menu, off to its left) - a real click on unrelated page content
+    // moments after picking a select option must still close the menu; only
+    // a click plausibly within the select's own native popup should be
+    // withheld.
+    await page.evaluate((box) => {
+      var el = document.querySelector('select[name="context-menu-input-my-select"]');
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+
+      var $ = window.jQuery;
+      $('#context-menu-layer').trigger($.Event('mousedown', {
+        pageX: box.x - 100,
         pageY: box.y + box.height + 50,
         button: 0
       }));


### PR DESCRIPTION
Closes #744

## Problem

Choosing an option from a `type: 'select'` menu item nested inside a sub-sub-menu closed the whole menu tree in Firefox (Edge/Chrome were unaffected), as reported in #744.

## Root cause

`handle.layerClick` decides whether a `mousedown` is a genuine "click outside the menu" by looking at `document.elementFromPoint(x, y)` for the raw event coordinates and checking whether that lands inside `root.$menu`.

A native `<select>`'s options popup isn't part of the page's DOM/layout, so its rendered extent isn't constrained by the menu's own (possibly clipped) bounding box. Firefox is documented (see the plugin's own historical #114, where the original author diagnosed Firefox firing extra mouse events around a `<select>`'s native popup that don't correspond to a real page interaction) to fire an extra click/mousedown shortly after a selection, at coordinates that can fall outside that bounding box - even though the user's interaction never actually left the menu. `layerClick` then (correctly, by its own logic, but incorrectly for this case) treated that as an outside click and hid the menu.

## Fix

Track the timestamp of the last `change` event fired by any `type: 'select'` menu input, and briefly (500ms) suppress outside-click handling in `layerClick` right after it. A plain outside click with no preceding select interaction is unaffected; only a mousedown arriving shortly after choosing an option from a menu's own `<select>` is ignored.

## Tests

- `test/specs/select-in-submenu.js` (new):
  - Functional sanity check: choosing an option via `selectOption()` keeps the whole menu open (this alone would *not* have caught the bug - Playwright's `selectOption()` doesn't drive the browser's actual native popup, which no automation framework can do reliably across browsers/platforms - see comments in the test for detail).
  - A synthetic reproduction of the actual mechanism (`change` event + a `mousedown` dispatched directly on `#context-menu-layer` at coordinates below the menu's bounding box) that fails against the old code and passes with the fix.
  - A companion test confirming a genuine outside click with **no** preceding select change still closes the menu as before.
- `npm run test-unit` (karma/qunit, ChromeHeadless): 31/31 pass.
- `npm run test:fixtures && npx playwright test` (chromium): 18/18 pass.
- Manually verified locally against real Firefox 153 (installed via `npx playwright install firefox` + a temporary `firefox` project in `playwright.config.js`, not committed - see note below) with the same tests: all pass. I didn't keep the `firefox` project permanently since the acceptance-tests CI workflow (`.github/workflows/tests.yml`) only installs the `chromium` browser (`npx playwright install --with-deps chromium`); wiring up permanent Firefox CI coverage would need a workflow change too, which felt out of scope for this fix.

Only `src/`, `test/`, and `documentation/` are touched - no `dist/*` changes (rebuilt at publish time).