### PR TITLE
fix: apply dataAttr to menu items and use the right attribute names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 * Context menu no longer jumps to the top of the screen #749
+* `dataAttr` is now applied to the menu items themselves, as documented, and writes every key of the object using the correct attribute name (fixes #732, fixes #712)
 
 ### 2.10.2
 

--- a/documentation/docs/items.md
+++ b/documentation/docs/items.md
@@ -24,6 +24,7 @@ currentMenu: items
   - [height](#height)
   - [items](#items)
   - [accesskey](#accesskey)
+  - [dataAttr](#dataattr)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -524,7 +525,13 @@ $.contextMenu({
 
 ### dataAttr
 
-Allows to pass data attributes (`data-*`) that get applied to the menu item. It should be passed as an object with key and a value.
+Allows to pass data attributes (`data-*`) that get applied to the menu item. It should be passed as an object of keys and values. Every key of the object is applied.
+
+Keys are converted from camelCase to the dashed form HTML uses, so `menuTitle` becomes `data-menu-title` and can be read back with `$item.data('menuTitle')`. Keys that already use dashes are left alone.
+
+Values are set as attributes, so they are never treated as HTML. Numbers and booleans are converted to their string form, `null` and `undefined` values are skipped.
+
+`dataAttr`: `object`
 
 #### Example
 
@@ -533,8 +540,29 @@ var items = {
     firstCommand: {
         name: "Copy",
         dataAttr: {
-            menuTitle: "My custom title"            
-        }           
+            menuTitle: "My custom title",
+            commandId: 42
+        }
     }
 }
+```
+
+This renders the item as:
+
+```html
+<li class="context-menu-item" data-menu-title="My custom title" data-command-id="42">Copy</li>
+```
+
+The same option is available on the menu itself, where it applies the data attributes to the menu's `<ul class="context-menu-list">`:
+
+```javascript
+$.contextMenu({
+    selector: '.context-menu-one',
+    dataAttr: {
+        menuTitle: "My custom menu title"
+    },
+    items: {
+        firstCommand: {name: "Copy"}
+    }
+});
 ```

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1470,7 +1470,13 @@
                     // they're no longer a CSS descendant of the root menu.
                     opt.$menu.addClass('context-menu-rtl');
                 }
-                applyDataAttr(opt.$menu, opt.dataAttr);
+                // menu level data-* attributes. Only for the root menu: sub-menus
+                // are created by calling op.create() with the parent *item* as
+                // `opt`, so applying this here as well would put an item's
+                // `dataAttr` on both its <li> and its sub-menu <ul>.
+                if (opt === root) {
+                    applyDataAttr(opt.$menu, opt.dataAttr);
+                }
 
                 $.each(['callbacks', 'commands', 'inputs'], function (i, k) {
                     opt[k] = {};

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1470,11 +1470,7 @@
                     // they're no longer a CSS descendant of the root menu.
                     opt.$menu.addClass('context-menu-rtl');
                 }
-                if(opt.dataAttr){
-                    $.each(opt.dataAttr, function (key, item) {
-                        opt.$menu.attr('data-' + opt.key, item);
-                    });
-                }
+                applyDataAttr(opt.$menu, opt.dataAttr);
 
                 $.each(['callbacks', 'commands', 'inputs'], function (i, k) {
                     opt[k] = {};
@@ -1547,6 +1543,9 @@
                         'contextMenuRoot': root,
                         'contextMenuKey': key
                     });
+
+                    // arbitrary data-* attributes for this item
+                    applyDataAttr($t, item.dataAttr);
 
                     // register accesskey
                     // NOTE: the accesskey attribute should be applicable to any element, but Safari5 and Chrome13 still can't do that
@@ -2253,6 +2252,32 @@
         }
 
         return keys;
+    }
+
+    // apply a `dataAttr` option object as HTML5 data-* attributes on the given
+    // element. Keys are converted from camelCase to the dashed form the HTML
+    // spec (and jQuery's `.data()` getter) expects, so `{menuTitle: 'x'}` is
+    // written as `data-menu-title="x"` and reads back as `.data('menuTitle')`.
+    // Values are set through `.attr()` so they're escaped by the DOM instead of
+    // ever being interpolated into an HTML string. `null`/`undefined` values are
+    // skipped, everything else is stringified.
+    function applyDataAttr($element, dataAttr) {
+        if (!dataAttr || typeof dataAttr !== 'object') {
+            return;
+        }
+
+        $.each(dataAttr, function (key, value) {
+            if (value === null || typeof value === 'undefined') {
+                return;
+            }
+
+            var name = String(key).replace(/[A-Z]/g, '-$&').toLowerCase();
+            if (!name) {
+                return;
+            }
+
+            $element.attr('data-' + name, String(value));
+        });
     }
 
     // is the given contextMenu `selector` option an Element or jQuery object,

--- a/test/unit/data-attr.test.js
+++ b/test/unit/data-attr.test.js
@@ -1,0 +1,176 @@
+QUnit.module('dataAttr', {
+  afterEach: function() {
+    $.contextMenu('destroy');
+    var $fixture = $('#qunit-fixture');
+    if ($fixture.length) {
+      $fixture.html('');
+    }
+  }
+});
+
+function dataAttrFixture() {
+  var $fixture = $('#qunit-fixture');
+  if ($fixture.length === 0) {
+    $('<div id="qunit-fixture">').appendTo('body');
+    $fixture = $('#qunit-fixture');
+  }
+  return $fixture;
+}
+
+// Build a menu on a freshly appended trigger and return its root <ul>.
+function buildMenu(options) {
+  var $fixture = dataAttrFixture();
+  $fixture.append('<span class="context-menu-data-attr">right click me</span>');
+
+  $.contextMenu($.extend({selector: '.context-menu-data-attr'}, options));
+
+  var $trigger = $('.context-menu-data-attr');
+  $trigger.contextMenu();
+
+  return $trigger.data('contextMenu').$menu;
+}
+
+QUnit.test('a single item dataAttr key is applied to the item as a data-* attribute', function(assert) {
+  var $menu = buildMenu({
+    items: {
+      copy: {
+        name: 'Copy',
+        dataAttr: {
+          menuTitle: 'My custom title'
+        }
+      }
+    }
+  });
+
+  var $item = $menu.children('li').first();
+  assert.equal($item.attr('data-menu-title'), 'My custom title', 'camelCase key is written as a kebab-case data attribute');
+});
+
+QUnit.test('every key of the dataAttr object is applied, not just the first', function(assert) {
+  var $menu = buildMenu({
+    items: {
+      copy: {
+        name: 'Copy',
+        dataAttr: {
+          menuTitle: 'My custom title',
+          role: 'copy-command',
+          testId: 'copy-item'
+        }
+      }
+    }
+  });
+
+  var $item = $menu.children('li').first();
+  assert.equal($item.attr('data-menu-title'), 'My custom title', 'first key applied');
+  assert.equal($item.attr('data-role'), 'copy-command', 'second key applied');
+  assert.equal($item.attr('data-test-id'), 'copy-item', 'third key applied');
+  assert.notOk($item.attr('data-undefined'), 'no data-undefined attribute is written');
+});
+
+QUnit.test('dataAttr values round trip through .data()', function(assert) {
+  var $menu = buildMenu({
+    items: {
+      copy: {
+        name: 'Copy',
+        dataAttr: {
+          menuTitle: 'My custom title',
+          'already-kebab': 'kebab value'
+        }
+      }
+    }
+  });
+
+  var $item = $menu.children('li').first();
+  assert.equal($item.data('menuTitle'), 'My custom title', 'readable via the camelCase name');
+  assert.equal($item.data('menu-title'), 'My custom title', 'readable via the kebab-case name');
+  assert.equal($item.data('alreadyKebab'), 'kebab value', 'keys already in kebab-case are left alone');
+});
+
+QUnit.test('non-string dataAttr values are stringified and null/undefined are skipped', function(assert) {
+  var $menu = buildMenu({
+    items: {
+      copy: {
+        name: 'Copy',
+        dataAttr: {
+          count: 42,
+          enabled: true,
+          disabled: false,
+          zero: 0,
+          empty: '',
+          nothing: null,
+          missing: undefined
+        }
+      }
+    }
+  });
+
+  var $item = $menu.children('li').first();
+  assert.equal($item.attr('data-count'), '42', 'numbers are stringified');
+  assert.equal($item.attr('data-enabled'), 'true', 'true is stringified');
+  assert.equal($item.attr('data-disabled'), 'false', 'false is stringified');
+  assert.equal($item.attr('data-zero'), '0', 'zero is stringified, not treated as empty');
+  assert.equal($item.attr('data-empty'), '', 'empty strings are kept');
+  assert.strictEqual($item.attr('data-nothing'), undefined, 'null values are skipped');
+  assert.strictEqual($item.attr('data-missing'), undefined, 'undefined values are skipped');
+
+  assert.strictEqual($item.data('count'), 42, 'a numeric value reads back as a number');
+  assert.strictEqual($item.data('enabled'), true, 'a boolean value reads back as a boolean');
+});
+
+QUnit.test('a dataAttr value containing HTML is not interpreted as markup', function(assert) {
+  var payload = '<img src="x" onerror="window.__contextMenuDataAttrXss = true;">';
+  var $menu = buildMenu({
+    items: {
+      copy: {
+        name: 'Copy',
+        dataAttr: {
+          menuTitle: payload
+        }
+      }
+    }
+  });
+
+  var $item = $menu.children('li').first();
+  assert.equal($item.attr('data-menu-title'), payload, 'the value is stored verbatim');
+  assert.equal($item.find('img').length, 0, 'no element was created from the value');
+  assert.notOk(window.__contextMenuDataAttrXss, 'no inline handler ran');
+});
+
+QUnit.test('dataAttr works for sub-menu items too', function(assert) {
+  var $menu = buildMenu({
+    items: {
+      more: {
+        name: 'More',
+        items: {
+          sub: {
+            name: 'Sub item',
+            dataAttr: {
+              menuTitle: 'Sub title'
+            }
+          }
+        }
+      }
+    }
+  });
+
+  var $subItem = $menu.find('.context-menu-submenu > .context-menu-list > li').first();
+  assert.equal($subItem.length, 1, 'sanity check: sub-menu item was found');
+  assert.equal($subItem.attr('data-menu-title'), 'Sub title', 'sub-menu items get their data attributes');
+});
+
+QUnit.test('menu level dataAttr is applied to the menu itself with the right attribute names', function(assert) {
+  var $menu = buildMenu({
+    dataAttr: {
+      menuTitle: 'Root menu',
+      role: 'menu-root'
+    },
+    items: {
+      copy: {name: 'Copy'}
+    }
+  });
+
+  assert.equal($menu.attr('data-menu-title'), 'Root menu', 'camelCase key is written as a kebab-case data attribute');
+  assert.equal($menu.attr('data-role'), 'menu-root', 'every key is applied');
+  assert.notOk($menu.attr('data-undefined'), 'no data-undefined attribute is written (issue #712)');
+  assert.equal($menu.data('menuTitle'), 'Root menu', 'readable via .data()');
+});

--- a/test/unit/data-attr.test.js
+++ b/test/unit/data-attr.test.js
@@ -158,6 +158,30 @@ QUnit.test('dataAttr works for sub-menu items too', function(assert) {
   assert.equal($subItem.attr('data-menu-title'), 'Sub title', 'sub-menu items get their data attributes');
 });
 
+QUnit.test('dataAttr of an item that has a sub-menu is not repeated on that sub-menu', function(assert) {
+  var $menu = buildMenu({
+    items: {
+      more: {
+        name: 'More',
+        dataAttr: {
+          commandId: 'more-command'
+        },
+        items: {
+          sub: {name: 'Sub item'}
+        }
+      }
+    }
+  });
+
+  var $item = $menu.children('li').first();
+  assert.equal($item.attr('data-command-id'), 'more-command', 'the item itself gets the attribute');
+
+  var $subMenu = $item.children('.context-menu-list');
+  assert.equal($subMenu.length, 1, 'sanity check: sub-menu was found');
+  assert.strictEqual($subMenu.attr('data-command-id'), undefined, 'the sub-menu does not get the item attribute');
+  assert.equal($menu.find('[data-command-id]').addBack('[data-command-id]').length, 1, 'only one element matches the attribute selector');
+});
+
 QUnit.test('menu level dataAttr is applied to the menu itself with the right attribute names', function(assert) {
   var $menu = buildMenu({
     dataAttr: {


### PR DESCRIPTION
## What

`dataAttr` was added in 2.9.0 and documented in `documentation/docs/items.md` as an **item** option, but the implementation only ever looked at `opt.dataAttr` (the menu options) and applied it to the menu's `<ul class="context-menu-list">`. Items never received any data attributes, which is what #732 reports.

The menu level path was broken too. It did:

```js
$.each(opt.dataAttr, function (key, item) {
    opt.$menu.attr('data-' + opt.key, item);
});
```

`opt.key` is always undefined, so instead of one attribute per key you got a single `data-undefined` attribute holding whichever value happened to come last. That is exactly what #712 describes.

## How

Both paths now go through one small helper, `applyDataAttr($element, dataAttr)`:

* iterates every key with `$.each`, so multi key objects work (the patch suggested in the issue only handled the first key)
* converts camelCase keys to the dashed form HTML uses, using the same rule jQuery's own `.data()` getter uses (`key.replace(/[A-Z]/g, '-$&').toLowerCase()`), so `menuTitle` is written as `data-menu-title` and reads back as `$item.data('menuTitle')` on jQuery 1, 2, 3 and 4. Keys that already use dashes are left alone.
* sets values with `.attr()`, so a value is never interpolated into an HTML string and cannot inject markup
* stringifies non string values (numbers, booleans) and skips `null` / `undefined` instead of writing `"null"` or removing attributes

Item attributes are applied on the `<li>` right after its `contextMenu` data is set, so they work for root items and sub-menu items alike. The menu level option keeps working, now with correct attribute names.

## Tests

New `test/unit/data-attr.test.js` covers a single key, multiple keys, camelCase to kebab conversion, the `.data()` round trip, non string and null/undefined values, values containing HTML not being interpreted as markup, sub-menu items, and the menu level case. Verified locally against jQuery 1, 2, 3 and 4, plus the Playwright acceptance suite.

Docs for the option have been expanded with the attribute naming rule, value handling, the rendered output and the menu level form.

Closes #732

Related to #712. The `data-undefined` bug reported there is fixed by the same helper, but I have left that issue open for a maintainer to close.