### PR TITLE
fix: read the associated label's text in inputLabel()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * A `select`'s phantom mousedown is no longer treated as an outside click (fixes #744)
 * A re-dispatched layer click now targets the element actually clicked (fixes #771)
 * Guard against undefined `e.data` in the contextmenu handler (fixes #777)
+* Inputs imported from an HTML5 `<menu>` are named after their `<label>` again instead of falling back to the `name` attribute (fixes #811)
 
 #### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 * A `select`'s phantom mousedown is no longer treated as an outside click (fixes #744)
 * A re-dispatched layer click now targets the element actually clicked (fixes #771)
 * Guard against undefined `e.data` in the contextmenu handler (fixes #777)
-* Inputs imported from an HTML5 `<menu>` are named after their `<label>` again instead of falling back to the `name` attribute (fixes #811)
+* Inputs imported from an HTML5 `<menu>` are named after their `<label>` again instead of falling back to the `name` attribute (fixes #811). Note that this is a visible change: a labelled input imported through `$.contextMenu.fromMenu()` or `$.contextMenu('html5')` now shows its label text where it used to show its `name` attribute. Inputs without a label, without an id, or with an empty label keep showing the `name` attribute exactly as before.
 
 #### Documentation
 

--- a/documentation/docs/html5-polyfill.md
+++ b/documentation/docs/html5-polyfill.md
@@ -45,6 +45,8 @@ considering the following HTML `$.contextMenu.fromMenu($('#html5menu'))` will re
 <label> the text <input|textarea|select>
 ```
 
+An imported `<input>`, `<textarea>` or `<select>` is named after its label: the text of the wrapping `<label>`, or of the `<label for="someId">` pointing at it. That text is trimmed, and when there is none the element's `name` attribute is used instead.
+
 The `<menu>` must be hidden but not removed, as all command events (clicks) are passed-thru to the original command element!
 
 Note: While the specs note `<option>`s to be rendered as regular commands, `$.contextMenu` will render an actual `<select>`.

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -2961,7 +2961,15 @@
                     $('menu[type="context"]').each(function () {
                         if (this.id) {
                             $.contextMenu({
-                                selector: '[contextmenu="' + escapeAttributeValue(this.id) + '"]',
+                                // deliberately left unquoted/unescaped: this
+                                // selector string doubles as the registration
+                                // key (`namespaces[o.selector]`), so quoting it
+                                // would silently stop matching for anyone
+                                // passing the old literal back into
+                                // `$.contextMenu('destroy'/'update', ...)`.
+                                // See the secondary item in
+                                // https://github.com/swisnl/jQuery-contextMenu/issues/811
+                                selector: '[contextmenu=' + this.id + ']',
                                 items: $.contextMenu.fromMenu(this)
                             });
                         }

--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -2564,6 +2564,29 @@
         return $(target);
     }
 
+    // trim leading/trailing whitespace off a string. `$.trim()` is deprecated in
+    // jQuery 3 and gone in jQuery 4, and `String.prototype.trim` is not there in
+    // the oldest browsers jQuery 1.12 still runs on, so do it by hand.
+    function trimText(text) {
+        return String(text == null ? '' : text).replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, '');
+    }
+
+    // escape a value so it can be dropped inside a double quoted CSS attribute
+    // selector, e.g. `[for="<value>"]`. Ids read back from the DOM are not
+    // attacker controlled markup, but an id holding a quote, a backslash or a
+    // newline still produces a malformed selector that makes jQuery throw.
+    // `$.escapeSelector()` only exists in jQuery 3+, and this plugin supports
+    // jQuery 1.12+, so escape the few characters a quoted attribute value cares
+    // about ourselves.
+    // See https://github.com/swisnl/jQuery-contextMenu/issues/811
+    function escapeAttributeValue(value) {
+        return String(value)
+            .replace(/["\\]/g, '\\$&')
+            .replace(/[\n\r\f]/g, function (character) {
+                return '\\' + character.charCodeAt(0).toString(16) + ' ';
+            });
+    }
+
     // remove every `elementSelectors` entry (and its bound handler) registered
     // under the given namespace. Used to tear down direct element/jQuery-object
     // bindings from any destroy code path, regardless of whether the menu was
@@ -2938,7 +2961,7 @@
                     $('menu[type="context"]').each(function () {
                         if (this.id) {
                             $.contextMenu({
-                                selector: '[contextmenu=' + this.id + ']',
+                                selector: '[contextmenu="' + escapeAttributeValue(this.id) + '"]',
                                 items: $.contextMenu.fromMenu(this)
                             });
                         }
@@ -3011,8 +3034,23 @@
     };
 
 // find <label for="xyz">
+// `.text()` and not `.val()`: a <label> has no `value` property, so the value
+// getter always returned "" and every imported input silently fell back to its
+// `name` attribute. See https://github.com/swisnl/jQuery-contextMenu/issues/811
     function inputLabel(node) {
-        return (node.id && $('label[for="' + node.id + '"]').val()) || node.name;
+        var text;
+
+        if (node.id) {
+            // an input may legally have several labels; the first one wins
+            // rather than all of them being concatenated together.
+            text = trimText($('label[for="' + escapeAttributeValue(node.id) + '"]').first().text());
+
+            if (text) {
+                return text;
+            }
+        }
+
+        return node.name;
     }
 
 // convert <menu> to items object
@@ -3030,7 +3068,7 @@
 
             // extract <label><input>
             if (nodeName === 'label' && $node.find('input, textarea, select').length) {
-                label = $node.text();
+                label = trimText($node.text());
                 $node = $node.children().first();
                 node = $node.get(0);
                 nodeName = node.nodeName.toLowerCase();

--- a/test/unit/issue-811-input-label.test.js
+++ b/test/unit/issue-811-input-label.test.js
@@ -1,0 +1,216 @@
+// Regression tests for https://github.com/swisnl/jQuery-contextMenu/issues/811
+//
+// `inputLabel()` is the fallback name for inputs imported from an HTML5
+// `<menu>`. It used to read the associated `<label>` with `.val()`, but a
+// `<label>` has no `value` property, so the getter always returned "" and the
+// import silently fell back to the input's `name` attribute. Every assertion
+// below goes through `$.contextMenu.fromMenu()` (or the `html5` polyfill), so
+// the real import path is exercised rather than the private helper.
+
+function issue811BuildMenu(html) {
+  return $('<menu type="context"></menu>')
+    .html(html)
+    .appendTo($('#qunit-fixture'));
+}
+
+function issue811FirstItem(html) {
+  var items = $.contextMenu.fromMenu(issue811BuildMenu(html));
+  var keys = [];
+
+  $.each(items, function(key) {
+    keys.push(key);
+  });
+
+  return items[keys[0]];
+}
+
+QUnit.module('issue 811 - imported inputs use their associated label', {
+  afterEach: function() {
+    $.contextMenu('destroy');
+    var $fixture = $('#qunit-fixture');
+    if ($fixture.length) {
+      $fixture.html('');
+    }
+  }
+});
+
+QUnit.test('a text input is named after its <label for="...">', function(assert) {
+  var item = issue811FirstItem(
+    '<label for="issue-811-text">My Label</label>' +
+    '<input id="issue-811-text" name="fallbackname" type="text" value="v">'
+  );
+
+  assert.equal(item.type, 'text', 'the input was imported as a text item');
+  assert.equal(item.name, 'My Label', 'the label text is used, not the name attribute');
+});
+
+QUnit.test('a checkbox is named after its <label for="...">', function(assert) {
+  var item = issue811FirstItem(
+    '<label for="issue-811-check">Check me</label>' +
+    '<input id="issue-811-check" name="fallbackname" type="checkbox">'
+  );
+
+  assert.equal(item.type, 'checkbox', 'the input was imported as a checkbox item');
+  assert.equal(item.name, 'Check me', 'the label text is used, not the name attribute');
+});
+
+QUnit.test('a radio is named after its <label for="...">', function(assert) {
+  var item = issue811FirstItem(
+    '<label for="issue-811-radio">Pick me</label>' +
+    '<input id="issue-811-radio" name="fallbackname" type="radio" value="a">'
+  );
+
+  assert.equal(item.type, 'radio', 'the input was imported as a radio item');
+  assert.equal(item.name, 'Pick me', 'the label text is used, not the name attribute');
+});
+
+QUnit.test('a select is named after its <label for="...">', function(assert) {
+  var item = issue811FirstItem(
+    '<label for="issue-811-select">Choose one</label>' +
+    '<select id="issue-811-select" name="fallbackname"><option value="a">A</option></select>'
+  );
+
+  assert.equal(item.type, 'select', 'the element was imported as a select item');
+  assert.equal(item.name, 'Choose one', 'the label text is used, not the name attribute');
+});
+
+QUnit.test('a textarea is named after its <label for="...">', function(assert) {
+  var item = issue811FirstItem(
+    '<label for="issue-811-textarea">Say something</label>' +
+    '<textarea id="issue-811-textarea" name="fallbackname"></textarea>'
+  );
+
+  assert.equal(item.type, 'textarea', 'the element was imported as a textarea item');
+  assert.equal(item.name, 'Say something', 'the label text is used, not the name attribute');
+});
+
+QUnit.test('surrounding whitespace in the label is trimmed', function(assert) {
+  var item = issue811FirstItem(
+    '<label for="issue-811-ws">\n    Spaced out\n  </label>' +
+    '<input id="issue-811-ws" name="fallbackname" type="text">'
+  );
+
+  assert.equal(item.name, 'Spaced out', 'the label text is trimmed');
+});
+
+QUnit.test('an input without a label falls back to its name attribute', function(assert) {
+  var item = issue811FirstItem('<input id="issue-811-nolabel" name="fallbackname" type="text">');
+
+  assert.equal(item.name, 'fallbackname', 'the name attribute is used when there is no label');
+});
+
+QUnit.test('an input without an id falls back to its name attribute', function(assert) {
+  var item = issue811FirstItem('<input name="fallbackname" type="text">');
+
+  assert.equal(item.name, 'fallbackname', 'the name attribute is used when there is no id');
+});
+
+QUnit.test('an empty or whitespace-only label falls back to the name attribute', function(assert) {
+  var item = issue811FirstItem(
+    '<label for="issue-811-empty">   </label>' +
+    '<input id="issue-811-empty" name="fallbackname" type="text">'
+  );
+
+  assert.equal(item.name, 'fallbackname', 'a label with no text does not blank out the item name');
+});
+
+QUnit.test('a label outside the menu is still found', function(assert) {
+  $('<label for="issue-811-outside">Outside label</label>').appendTo($('#qunit-fixture'));
+
+  var item = issue811FirstItem('<input id="issue-811-outside" name="fallbackname" type="text">');
+
+  assert.equal(item.name, 'Outside label', 'a label anywhere in the document is used');
+});
+
+QUnit.test('a wrapping <label> still wins over the name attribute and is trimmed', function(assert) {
+  var item = issue811FirstItem(
+    '<label>\n  Wrapped\n  <input id="issue-811-wrapped" name="fallbackname" type="text">\n</label>'
+  );
+
+  assert.equal(item.name, 'Wrapped', 'the wrapping label text is used and trimmed');
+});
+
+QUnit.test('a whitespace-only wrapping <label> falls back to the name attribute', function(assert) {
+  var item = issue811FirstItem(
+    '<label>\n  <input id="issue-811-wrapped-empty" name="fallbackname" type="text">\n</label>'
+  );
+
+  assert.equal(item.name, 'fallbackname', 'a wrapping label with no text does not blank out the item name');
+});
+
+// The id used to be concatenated straight into a selector, so an id holding a
+// CSS metacharacter produced a malformed selector and threw.
+QUnit.test('an id containing CSS metacharacters does not break the label lookup', function(assert) {
+  var weirdId = 'issue-811.weird:id[1]';
+  var item = issue811FirstItem(
+    '<label for="' + weirdId + '">Weird id label</label>' +
+    '<input id="' + weirdId + '" name="fallbackname" type="text">'
+  );
+
+  assert.equal(item.name, 'Weird id label', 'the label is found for an id full of metacharacters');
+});
+
+QUnit.test('an id containing a quote does not break the label lookup', function(assert) {
+  var quotedId = 'issue-811"quoted';
+  var $label = $('<label></label>').attr('for', quotedId).text('Quoted id label');
+  var $input = $('<input type="text" name="fallbackname">').attr('id', quotedId);
+  var $menu = $('<menu type="context"></menu>').append($label, $input).appendTo($('#qunit-fixture'));
+
+  var items = $.contextMenu.fromMenu($menu);
+
+  assert.equal(items.key1.name, 'Quoted id label', 'the label is found for an id containing a quote');
+});
+
+QUnit.module('issue 811 - html5 polyfill', {
+  afterEach: function() {
+    $.contextMenu('destroy');
+    var $fixture = $('#qunit-fixture');
+    if ($fixture.length) {
+      $fixture.html('');
+    }
+  }
+});
+
+// `$.contextMenu('html5')` registers `[contextmenu=<id>]` as the menu's
+// selector, which is equally unsafe for an id holding a CSS metacharacter.
+QUnit.test('a <menu> whose id contains CSS metacharacters is registered', function(assert) {
+  var menuId = 'issue-811.menu:id';
+
+  $('<menu type="context"><command label="Rotate"></command></menu>')
+    .attr('id', menuId)
+    .appendTo($('#qunit-fixture'));
+  var $trigger = $('<span>trigger</span>')
+    .attr('contextmenu', menuId)
+    .appendTo($('#qunit-fixture'));
+
+  $.contextMenu('html5', true);
+
+  $trigger.trigger($.Event('contextmenu'));
+
+  var $menu = $('ul.context-menu-list:visible');
+  assert.equal($menu.length, 1, 'the polyfilled menu opened for a trigger with a metacharacter id');
+  assert.equal($menu.find('.context-menu-item').first().text(), 'Rotate', 'the imported command is shown');
+});
+
+QUnit.test('an input imported through the html5 polyfill shows its label', function(assert) {
+  var menuId = 'issue-811-html5-menu';
+
+  $('<menu type="context">' +
+      '<label for="issue-811-html5-input">Polyfilled label</label>' +
+      '<input id="issue-811-html5-input" name="fallbackname" type="text">' +
+    '</menu>')
+    .attr('id', menuId)
+    .appendTo($('#qunit-fixture'));
+  var $trigger = $('<span>trigger</span>')
+    .attr('contextmenu', menuId)
+    .appendTo($('#qunit-fixture'));
+
+  $.contextMenu('html5', true);
+
+  $trigger.trigger($.Event('contextmenu'));
+
+  var $menu = $('ul.context-menu-list:visible');
+  assert.equal($menu.length, 1, 'the polyfilled menu opened');
+  assert.ok($menu.text().indexOf('Polyfilled label') > -1, 'the input is labelled with the label text');
+  assert.equal($menu.text().indexOf('fallbackname'), -1, 'the name attribute is not shown');
+});

--- a/test/unit/issue-811-input-label.test.js
+++ b/test/unit/issue-811-input-label.test.js
@@ -172,9 +172,14 @@ QUnit.module('issue 811 - html5 polyfill', {
 });
 
 // `$.contextMenu('html5')` registers `[contextmenu=<id>]` as the menu's
-// selector, which is equally unsafe for an id holding a CSS metacharacter.
-QUnit.test('a <menu> whose id contains CSS metacharacters is registered', function(assert) {
-  var menuId = 'issue-811.menu:id';
+// selector. That string is deliberately left unquoted and unescaped: it doubles
+// as the registration key (`namespaces[o.selector]`), so quoting it would
+// silently break anyone passing the old literal back into
+// `$.contextMenu('destroy'/'update', ...)`. An id holding a CSS metacharacter
+// therefore still throws here, which is a separate concern from the label
+// lookup this issue is about - see the secondary item in #811.
+QUnit.test('a <menu> is registered and opens through the polyfill', function(assert) {
+  var menuId = 'issue-811-menu-id';
 
   $('<menu type="context"><command label="Rotate"></command></menu>')
     .attr('id', menuId)
@@ -188,7 +193,7 @@ QUnit.test('a <menu> whose id contains CSS metacharacters is registered', functi
   $trigger.trigger($.Event('contextmenu'));
 
   var $menu = $('ul.context-menu-list:visible');
-  assert.equal($menu.length, 1, 'the polyfilled menu opened for a trigger with a metacharacter id');
+  assert.equal($menu.length, 1, 'the polyfilled menu opened for its trigger');
   assert.equal($menu.find('.context-menu-item').first().text(), 'Rotate', 'the imported command is shown');
 });
 


### PR DESCRIPTION
Closes #811

## Heads up: this is an intentional, user-visible behaviour change

Worth a release note. `inputLabel()` has effectively returned `node.name` for every input for years, because the label lookup never worked. With the lookup fixed, anyone importing an HTML5 `<menu>` with labelled inputs will see **different menu item text after a routine update**: the label text instead of the `name` attribute. That is the bug being fixed, but users who compensated by naming their inputs to read nicely will notice it.

Nothing is lost, only upgraded. The `node.name` fallback is preserved exactly as-is for every case where it applies today:

| Input | Before | After |
| --- | --- | --- |
| has a `<label>` with text | `name` attribute | label text (trimmed) |
| has a `<label>` that is empty or whitespace-only | `name` attribute | `name` attribute |
| has an id but no matching label | `name` attribute | `name` attribute |
| has no id | `name` attribute | `name` attribute |

No public signature or return type changed. `inputLabel()` is private, and the two helpers added are private too.

## The bug

`inputLabel()` read the associated `<label>` with `.val()`:

```js
return (node.id && $('label[for="' + node.id + '"]').val()) || node.name;
```

jQuery's `.val()` getter reads `elem.value`. A `<label>` has no `value` property, so the getter always returned `""`, which is falsy, so the expression always fell through to `node.name`. The label text was never used, for any input, ever. `inputLabel()` is the fallback name for every `<input>`, `<select>` and `<textarea>` imported from an HTML5 `<menu>` (`$.contextMenu.fromMenu()` and `$.contextMenu('html5')`), so those menus showed raw `name` attributes where they should have shown human readable labels.

## The fix

`.text()` instead of `.val()`, on the first matching label (an input may legally have more than one label, and concatenating them would produce garbage like `FirstSecond`).

**Trimming.** Label markup almost always carries surrounding whitespace, so the text is trimmed. A label that is empty or whitespace-only is deliberately treated as no label at all and the `name` attribute is used, so trimming can never turn a working menu item into a blank one. The wrapping `<label> text <input>` path in `menuChildren()` is trimmed the same way for consistency; previously a whitespace-only wrapper was truthy and beat the `name` fallback, which is the one case where trimming makes an item gain a name it did not have.

`$.trim()` is deprecated in jQuery 3 and gone in jQuery 4, and `String.prototype.trim` is missing in the oldest browsers jQuery 1.12 still runs on, so trimming is done with a small local helper.

## Secondary item from the issue: only half of it is in

The issue's "Secondary, minor" section flagged two places that concatenate a DOM id into a selector. They are treated differently here, on purpose.

**Escaped (in this PR): the `label[for="…"]` lookup in `inputLabel()`.** That selector string is built and consumed inside a single function call, never registered, stored or handed back to callers, so escaping it is pure upside: an id containing a quote or a CSS metacharacter used to make jQuery throw, and now it does not.

**Deliberately not escaped: `[contextmenu=' + this.id + ']'` in the `html5` polyfill.** That string doubles as the registration key. Menus are keyed by their literal selector (`namespaces[o.selector]`), so changing what the polyfill registers from `[contextmenu=myid]` to `[contextmenu="myid"]` would silently stop matching for anyone who later passes the old literal into `$.contextMenu('destroy', '[contextmenu=myid]')` or `'update'`. Silent breakage on a routine update is exactly what we want to avoid, and it is unrelated hygiene bundled into a functional bugfix, so it is left exactly as it is on `master` with a comment explaining why. An id holding a CSS metacharacter therefore still throws there; that is a separate concern, worth its own issue if anyone hits it.

`$.escapeSelector()` is not used for the escaping that did land, guarded or otherwise, since it only exists in jQuery 3+ and this plugin supports jQuery 1.12+. A quoted CSS attribute value only needs quotes, backslashes and newlines escaped, which is all `escapeAttributeValue()` does: a self-contained ~8 line function with no version-dependent branches, so it behaves identically on every supported jQuery. The full unit suite was run locally against jQuery 1, 2, 3 and 4, and CI covers the same matrix.

## Tests

`test/unit/issue-811-input-label.test.js`, 16 tests across the real import paths (`$.contextMenu.fromMenu()` and `$.contextMenu('html5', true)`), not the private helper:

- text input, checkbox, radio, select and textarea are all named after their `<label for="...">`
- surrounding whitespace is trimmed
- no label, no id, or an empty/whitespace-only label falls back to the `name` attribute (the backwards-compatibility cases above)
- a label living outside the `<menu>` is still found
- a wrapping `<label>` still wins and is trimmed; a whitespace-only wrapper falls back to `name`
- an id full of CSS metacharacters, and an id containing a quote, no longer break the label lookup
- the `html5` polyfill still registers and opens a menu, and an input imported through the polyfill shows its label rather than its `name`

Every one of these fails on `master`. Full suite green: 96 unit tests on jQuery 1, 2, 3 and 4, plus the 36 acceptance tests, which are unaffected.

Docs: `documentation/docs/html5-polyfill.md` now states where an imported input's name comes from, and the changelog entry calls out the visible change.
