### PR TITLE
ci: retry acceptance tests on CI to absorb runner flake

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -5,6 +5,13 @@ module.exports = defineConfig({
   testDir: './test/specs',
   testMatch: '*.js',
   fullyParallel: true,
+  // Retry on CI only. The specs themselves are deterministic, but the runner is
+  // shared and oversubscribed, and a loaded one occasionally takes longer than
+  // the 30s default timeout just to load a fixture page - the failure is a
+  // `page.goto` timeout rather than a failed assertion. Without retries a single
+  // slow page load fails a whole matrix row. Locally, retries would only hide
+  // a genuinely flaky spec, so leave them off there.
+  retries: process.env.CI ? 2 : 0,
   reporter: 'list',
   use: {
     trace: 'retain-on-failure',


### PR DESCRIPTION
## Problem

`playwright.config.js` sets `fullyParallel: true` but never sets `retries`, so Playwright's default of `0` applies. A single transient failure therefore takes down a whole matrix row and reports the build as broken.

This is happening regularly. Three runs in one four-minute window failed, on three different specs, one of them on `master`:

| Run | Branch | Failing spec | Mode |
|---|---|---|---|
| [30516706190](https://github.com/swisnl/jQuery-contextMenu/actions/runs/30516706190) | `master` | `select-in-submenu.js:108` | timeout after 35.0s |
| [30516766062](https://github.com/swisnl/jQuery-contextMenu/actions/runs/30516766062) | `fix/issue-809-context-element` | `nested-triggers-autohide.js:49` | `page.goto` timeout |
| [30516702187](https://github.com/swisnl/jQuery-contextMenu/actions/runs/30516702187) | `fix/issue-812-xy-overload` | `menu-title-icon-alignment.js:70` | `page.goto` timeout |

A different spec each time, and every failure is a *timeout* rather than a failed assertion. Twice it was specifically `page.goto` never finishing the fixture page load inside the 30s default:

```
Test timeout of 30000ms exceeded while running "beforeEach" hook.
Error: page.goto: Test timeout of 30000ms exceeded.
  - navigating to "file:///.../jquery-2.2.4/nested-triggers-autohide.html", waiting until "load"
```

The runner is simply oversubscribed: specs that normally finish in 2-6s were taking 10-23s in those runs, and other tests in the very same file, sharing the same `beforeEach`, passed. Re-running the failed job on #817 passed 9/9 with no code change at all.

## Change

```js
retries: process.env.CI ? 2 : 0,
```

GitHub Actions sets `CI=true` automatically, so this is 2 on CI and 0 locally. Verified both ways, and `--list` still discovers all 38 tests in 12 files.

This is not loosening a tolerance. Every assertion stays exactly as strict, and a spec that genuinely fails still fails after three attempts. It only stops a loaded runner from being reported as a broken build. Retries stay off locally, where they would just mask a genuinely flaky spec.

## Possible follow-up, deliberately not done here

Capping `workers` on CI would attack the oversubscription directly rather than absorbing it. That is a bigger tuning decision with a wall-clock cost, so it is left out of this one-line fix.

No changelog entry: internal test tooling, nothing user-facing.